### PR TITLE
Add i18n translations on start screens

### DIFF
--- a/Wisdom_expo/languages/ar.json
+++ b/Wisdom_expo/languages/ar.json
@@ -2,6 +2,24 @@
     "translation": {
         "skip_intro": "تخطي المقدمة",
         "hello": "مرحباً",
-        "profile": "الملف الشخصي"
+        "profile": "الملف الشخصي",
+        "get_started": "ابدأ",
+        "by_tapping_get_started": "بالنقر على \"ابدأ\" أنت توافق على",
+        "terms": "الشروط",
+        "and": "و",
+        "privacy_policy": "سياسة الخصوصية.",
+        "email_missing": "البريد الإلكتروني أو اسم المستخدم مفقود",
+        "password_length_error": "يجب أن تكون كلمة المرور 8 أحرف على الأقل",
+        "password_incorrect": "كلمة المرور غير صحيحة.",
+        "wrong_user_or_password": "اسم المستخدم أو كلمة المرور غير صحيحة.",
+        "welcome_back": "مرحباً بعودتك",
+        "email_or_username": "البريد الإلكتروني أو اسم المستخدم",
+        "password": "كلمة المرور",
+        "forgot_password_question": "هل نسيت كلمة المرور؟",
+        "next": "التالي",
+        "enter_complete_name": "أدخل اسمك الكامل",
+        "name_and_surname": "الاسم واللقب",
+        "must_enter_surname": "يجب إدخال اللقب",
+        "must_enter_only_name_and_surname": "أدخل الاسم واللقب فقط"
     }
 }

--- a/Wisdom_expo/languages/ca.json
+++ b/Wisdom_expo/languages/ca.json
@@ -2,6 +2,24 @@
     "translation": {
         "skip_intro": "Saltar intro",
         "hello": "hola",
-        "profile": "Perfil"
+        "profile": "Perfil",
+        "get_started": "Començar",
+        "by_tapping_get_started": "En prémer \"Començar\" acceptes les nostres",
+        "terms": "Condicions",
+        "and": "i",
+        "privacy_policy": "Política de privacitat.",
+        "email_missing": "Falta el correu o usuari",
+        "password_length_error": "La contrasenya ha de tenir almenys 8 caràcters",
+        "password_incorrect": "Contrasenya incorrecta.",
+        "wrong_user_or_password": "Usuari o contrasenya incorrectes.",
+        "welcome_back": "Benvingut de nou",
+        "email_or_username": "Correu o usuari",
+        "password": "Contrasenya",
+        "forgot_password_question": "Has oblidat la contrasenya?",
+        "next": "Següent",
+        "enter_complete_name": "Introdueix el teu nom complet",
+        "name_and_surname": "Nom i Cognom",
+        "must_enter_surname": "Has d'introduir el cognom",
+        "must_enter_only_name_and_surname": "Introdueix només nom i cognom"
     }
 }

--- a/Wisdom_expo/languages/en.json
+++ b/Wisdom_expo/languages/en.json
@@ -3,6 +3,23 @@
         "skip_intro": "Skip intro",
         "hello": "hello",
         "profile": "Profile",
-        "get_started": "Get Started"
+        "get_started": "Get Started",
+        "by_tapping_get_started": "By tapping on \"Get Started\", you agree to our",
+        "terms": "Terms",
+        "and": "and",
+        "privacy_policy": "Privacy Policy.",
+        "email_missing": "Email or username is missing",
+        "password_length_error": "Password must be at least 8 characters long",
+        "password_incorrect": "Password incorrect.",
+        "wrong_user_or_password": "Wrong user or password.",
+        "welcome_back": "Welcome back",
+        "email_or_username": "Email or username",
+        "password": "Password",
+        "forgot_password_question": "Forgot Password?",
+        "next": "Next",
+        "enter_complete_name": "Enter your complete name",
+        "name_and_surname": "Name and Surname",
+        "must_enter_surname": "Must enter your surname",
+        "must_enter_only_name_and_surname": "Must enter only your name and surname"
     }
 }

--- a/Wisdom_expo/languages/es.json
+++ b/Wisdom_expo/languages/es.json
@@ -2,6 +2,24 @@
     "translation": {
         "skip_intro": "Saltar intro",
         "hello": "hola",
-        "profile": "Perfil"
+        "profile": "Perfil",
+        "get_started": "Empezar",
+        "by_tapping_get_started": "Al pulsar en \"Empezar\" aceptas nuestras",
+        "terms": "Condiciones",
+        "and": "y",
+        "privacy_policy": "Política de privacidad.",
+        "email_missing": "Falta el email o usuario",
+        "password_length_error": "La contraseña debe tener al menos 8 caracteres",
+        "password_incorrect": "Contraseña incorrecta.",
+        "wrong_user_or_password": "Usuario o contraseña incorrectos.",
+        "welcome_back": "Bienvenido de nuevo",
+        "email_or_username": "Email o usuario",
+        "password": "Contraseña",
+        "forgot_password_question": "¿Olvidaste la contraseña?",
+        "next": "Siguiente",
+        "enter_complete_name": "Introduce tu nombre completo",
+        "name_and_surname": "Nombre y Apellido",
+        "must_enter_surname": "Debes introducir tu apellido",
+        "must_enter_only_name_and_surname": "Debes introducir solo nombre y apellido"
     }
 }

--- a/Wisdom_expo/languages/fr.json
+++ b/Wisdom_expo/languages/fr.json
@@ -2,6 +2,24 @@
     "translation": {
         "skip_intro": "Sauter l'intro",
         "hello": "bonjour",
-        "profile": "Profil"
+        "profile": "Profil",
+        "get_started": "Commencer",
+        "by_tapping_get_started": "En appuyant sur \"Commencer\", vous acceptez nos",
+        "terms": "Conditions",
+        "and": "et",
+        "privacy_policy": "Politique de confidentialité.",
+        "email_missing": "Email ou utilisateur manquant",
+        "password_length_error": "Le mot de passe doit comporter au moins 8 caractères",
+        "password_incorrect": "Mot de passe incorrect.",
+        "wrong_user_or_password": "Utilisateur ou mot de passe incorrect.",
+        "welcome_back": "Bon retour",
+        "email_or_username": "Email ou utilisateur",
+        "password": "Mot de passe",
+        "forgot_password_question": "Mot de passe oublié ?",
+        "next": "Suivant",
+        "enter_complete_name": "Entrez votre nom complet",
+        "name_and_surname": "Nom et Prénom",
+        "must_enter_surname": "Vous devez entrer votre prénom",
+        "must_enter_only_name_and_surname": "Entrez seulement nom et prénom"
     }
 }

--- a/Wisdom_expo/languages/zh.json
+++ b/Wisdom_expo/languages/zh.json
@@ -2,6 +2,24 @@
     "translation": {
         "skip_intro": "跳过介绍",
         "hello": "你好",
-        "profile": "概况"
+        "profile": "概况",
+        "get_started": "开始",
+        "by_tapping_get_started": "点击\"开始\"即表示同意我们的",
+        "terms": "条款",
+        "and": "和",
+        "privacy_policy": "隐私政策。",
+        "email_missing": "缺少邮箱或用户名",
+        "password_length_error": "密码至少需要8个字符",
+        "password_incorrect": "密码不正确。",
+        "wrong_user_or_password": "用户名或密码不正确。",
+        "welcome_back": "欢迎回来",
+        "email_or_username": "邮箱或用户名",
+        "password": "密码",
+        "forgot_password_question": "忘记密码？",
+        "next": "下一步",
+        "enter_complete_name": "输入你的全名",
+        "name_and_surname": "名字和姓氏",
+        "must_enter_surname": "必须输入姓氏",
+        "must_enter_only_name_and_surname": "只输入名字和姓氏"
     }
 }

--- a/Wisdom_expo/screens/start/EnterNameScreen.js
+++ b/Wisdom_expo/screens/start/EnterNameScreen.js
@@ -34,12 +34,12 @@ export default function EnterNameScreen() {
       const nameSplited = name.trim().split(" ");
 
       if (nameSplited.length === 1){
-        setErrorMessage('Must enter your surname');
+        setErrorMessage(t('must_enter_surname'));
         setShowError(true);
         
       }
       else if (nameSplited.length > 2) {
-        setErrorMessage('Must enter only your name and surname');
+        setErrorMessage(t('must_enter_only_name_and_surname'));
         setShowError(true);
       }
       else {
@@ -61,11 +61,11 @@ export default function EnterNameScreen() {
                 <ChevronLeftIcon size={26} color={iconColor} strokeWidth="1.7" className="p-6"/>
             </TouchableOpacity>
             <Text className="font-inter-bold text-xl pt-11 text-[#444343] dark:text-[#f2f2f2]">
-                Enter your complete name
+                {t('enter_complete_name')}
             </Text>
             <View className="mt-7 h-[55] flex-row justify-start items-center rounded-full bg-[#E0E0E0]/60 dark:bg-[#3D3D3D]/60 border-[1px] border-[#706F6E]/20 dark:border-[#B6B5B5]/20">
-                <TextInput 
-                placeholder='Name and Surname' 
+                <TextInput
+                placeholder={t('name_and_surname')}
                 autoFocus={true} 
                 selectionColor={cursorColorChange} 
                 placeholderTextColor={placheHolderTextColorChange} 
@@ -89,7 +89,7 @@ export default function EnterNameScreen() {
                 onPress={nextPressed}
                 style={{opacity: name.length < 1 ? 0.5 : 1.0}}
                 className="bg-[#323131] dark:bg-[#fcfcfc] w-full h-[55] rounded-full items-center justify-center" >
-                    <Text className="font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131] ">Next </Text>
+                    <Text className="font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131] ">{t('next')} </Text>
                 </TouchableOpacity>
             </View>
         </KeyboardAvoidingView>

--- a/Wisdom_expo/screens/start/GetStartedScreen.js
+++ b/Wisdom_expo/screens/start/GetStartedScreen.js
@@ -36,23 +36,23 @@ export default function GetStartedScreen() {
               </TouchableOpacity>
               <View className="w-[250]">
 
-                      <Text className="pt-3 text-[11px] font-inter-medium text-[#f2f2f2] opacity-60 text-center">By tapping on "Get Started", you agree to our </Text>
+                      <Text className="pt-3 text-[11px] font-inter-medium text-[#f2f2f2] opacity-60 text-center">{t('by_tapping_get_started')} </Text>
                       <View className="pb-5 flex-row justify-center items-center">
                         <TouchableOpacity 
                             hitSlop={{ top: 30, bottom: 30, left: 30, right: 30 }}
                             onPress={() => navigation.navigate('Terms')}
                         >
                             <Text className="text-[11px] font-inter-medium text-[#f2f2f2] opacity-60 text-center underline">
-                                Terms
+                                {t('terms')}
                             </Text>
                         </TouchableOpacity>
-                        <Text className="text-[11px] mx-1 font-inter-medium text-[#f2f2f2] opacity-60 text-center">and</Text>
+                        <Text className="text-[11px] mx-1 font-inter-medium text-[#f2f2f2] opacity-60 text-center">{t('and')}</Text>
                         <TouchableOpacity 
                             onPress={() => navigation.navigate('PrivacyPolicy')} 
                             hitSlop={{ top: 30, bottom: 30, left: 30, right: 30 }}
                         >
                             <Text className="text-[11px] font-inter-medium text-[#f2f2f2] opacity-60 text-center underline">
-                                Privacy Policy.
+                                {t('privacy_policy')}
                             </Text>
                         </TouchableOpacity>
                       </View>

--- a/Wisdom_expo/screens/start/LogInScreen.js
+++ b/Wisdom_expo/screens/start/LogInScreen.js
@@ -49,10 +49,10 @@ export default function LogInScreen() {
   const nextPressed = async () => {
     if (userEmail.length < 1) {
       setShowError(true);
-      setErrorMessage("Email or username is missing");
+      setErrorMessage(t('email_missing'));
     } else if (password.length < 8) {
       setShowError(true);
-      setErrorMessage("Password must be at least 8 characters long");
+      setErrorMessage(t('password_length_error'));
     } else {
       try {
         const response = await api.post('/api/login', {
@@ -71,10 +71,10 @@ export default function LogInScreen() {
           navigation.navigate('HomeScreen');
         } else if (response.data.success===false) {
           setShowError(true);
-          setErrorMessage('Password incorrect.');
+          setErrorMessage(t('password_incorrect'));
         } else {
           setShowError(true);
-          setErrorMessage('Wrong user or password.');
+          setErrorMessage(t('wrong_user_or_password'));
         };
       } catch (error) {
         console.error('Login error:', error);
@@ -119,15 +119,15 @@ export default function LogInScreen() {
         </View>
 
         <Text className="font-inter-bold text-xl pt-4 text-center text-[#444343] dark:text-[#f2f2f2]">
-            Welcome back
+            {t('welcome_back')}
         </Text>
         <Text className="font-inter-semibold text-[15px] pt-10 text-[#444343] dark:text-[#f2f2f2]">
-          Email or username
+          {t('email_or_username')}
         </Text>
         
         <View className="mt-3 h-[55] flex-row justify-start items-center rounded-full bg-[#E0E0E0]/60 dark:bg-[#3D3D3D]/60 border-[1px] border-[#706F6E]/20 dark:border-[#B6B5B5]/20">
-            <TextInput 
-            placeholder='Email or username' 
+            <TextInput
+            placeholder={t('email_or_username')}
             autoFocus={true} 
             selectionColor={cursorColorChange} 
             placeholderTextColor={placeHolderTextColorChange} 
@@ -139,11 +139,11 @@ export default function LogInScreen() {
             className="px-4 h-11 text-[15px] text-[#444343] dark:text-[#f2f2f2]"/>
         </View>
         <Text className="font-inter-semibold text-[15px] pt-6 text-[#444343] dark:text-[#f2f2f2]">
-          Password
+          {t('password')}
         </Text>
         <View className="mt-3 px-5 h-[55] flex-row justify-between items-center rounded-full bg-[#E0E0E0]/60 dark:bg-[#3D3D3D]/60 border-[1px] border-[#706F6E]/20 dark:border-[#B6B5B5]/20">
           <TextInput
-            placeholder='password'
+            placeholder={t('password')}
             autoFocus={false}
             selectionColor={cursorColorChange}
             placeholderTextColor={placeHolderTextColorChange}
@@ -164,7 +164,7 @@ export default function LogInScreen() {
           
         </View>
         <TouchableOpacity onPress={() => navigation.navigate('ForgotPassword')}>
-          <Text style={{color:placeHolderTextColorChange}} className="text-right text-[13px] mt-2">Forgot Password?</Text>
+          <Text style={{color:placeHolderTextColorChange}} className="text-right text-[13px] mt-2">{t('forgot_password_question')}</Text>
         </TouchableOpacity>
         {
             showError? (
@@ -178,7 +178,7 @@ export default function LogInScreen() {
           onPress={nextPressed}
           style={{opacity: password.length < 1 || userEmail.length < 1 ? 0.5 : 1.0}}
           className="bg-[#323131] dark:bg-[#fcfcfc] w-full h-[55] rounded-full items-center justify-center">
-            <Text className="font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]">Next</Text>
+            <Text className="font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]">{t('next')}</Text>
           </TouchableOpacity>
         </View>
       </KeyboardAwareScrollView>


### PR DESCRIPTION
## Summary
- expand translation strings for multiple languages
- translate three start screens using new keys

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841674cdaf8832ba8249da0219983dd