### PR TITLE
Implement Firebase-based chat

### DIFF
--- a/Wisdom_expo/package-lock.json
+++ b/Wisdom_expo/package-lock.json
@@ -28,6 +28,7 @@
         "expo-blur": "~14.1.4",
         "expo-crypto": "~14.1.4",
         "expo-dev-client": "~5.1.8",
+        "expo-document-picker": "~13.1.5",
         "expo-font": "~13.3.1",
         "expo-image-picker": "~16.1.4",
         "expo-location": "~18.1.5",
@@ -6574,6 +6575,15 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-1.10.0.tgz",
       "integrity": "sha512-NxtM/qot5Rh2cY333iOE87dDg1S8CibW+Wu4WdLua3UMjy81pXYzAGCZGNOeY7k9GpNFqDPNDXWyBSlk9r2pBg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-13.1.5.tgz",
+      "integrity": "sha512-ELsGFW+k6xEkz7YKpop9u+9M9yUTNNruQdyKd2lSGR4thQFKRPOmKDsgYDZxc18hysGQN4evzp54lZqQwYdk4Q==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/Wisdom_expo/package.json
+++ b/Wisdom_expo/package.json
@@ -31,6 +31,7 @@
     "expo-dev-client": "~5.1.8",
     "expo-font": "~13.3.1",
     "expo-image-picker": "~16.1.4",
+    "expo-document-picker": "~13.1.5",
     "expo-location": "~18.1.5",
     "expo-random": "~14.0.1",
     "expo-splash-screen": "~0.30.8",

--- a/Wisdom_expo/screens/chat/ChatScreen.js
+++ b/Wisdom_expo/screens/chat/ChatScreen.js
@@ -1,5 +1,15 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image } from 'react-native';
+import React, { useEffect, useState, useCallback } from 'react';
+import {
+  View,
+  StatusBar,
+  SafeAreaView,
+  Platform,
+  TouchableOpacity,
+  Text,
+  FlatList,
+  ScrollView,
+  Image,
+} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import i18n from '../../languages/i18n';
@@ -9,6 +19,8 @@ import { ChatBubbleLeftRightIcon } from 'react-native-heroicons/solid';
 import { Calendar, Search } from "react-native-feather";
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import api from '../../utils/api.js';
+import { collection, query, where, orderBy, onSnapshot } from 'firebase/firestore';
+import { db } from '../../utils/firebase';
 
 
 export default function ChatScreen() {
@@ -19,12 +31,34 @@ export default function ChatScreen() {
   const navigation = useNavigation();
   const [selectedStatus, setSelectedStatus] = useState('all');
   const [userId, setUserId] = useState();
+  const [conversations, setConversations] = useState([]);
 
   const suggestions = [
     { label: t('all'), value: 'all', id: 1 },
     { label: t('professionals'), value: 'professionals', id: 2 },
     { label: t('help'), value: 'help', id: 3 },
   ];
+
+  useEffect(() => {
+    let unsubscribe;
+    const load = async () => {
+      const userData = await getDataLocally('user');
+      if (!userData) return;
+      const user = JSON.parse(userData);
+      setUserId(user.id);
+      const q = query(
+        collection(db, 'conversations'),
+        where('participants', 'array-contains', user.id),
+        orderBy('updatedAt', 'desc')
+      );
+      unsubscribe = onSnapshot(q, snap => {
+        const data = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+        setConversations(data);
+      });
+    };
+    load();
+    return () => unsubscribe && unsubscribe();
+  }, []);
 
   useFocusEffect(
     useCallback(() => {
@@ -77,7 +111,7 @@ export default function ChatScreen() {
           </ScrollView>
         </View>
 
-        {true ? (
+        {conversations.length < 1 ? (
           <View className="flex-1 justify-center items-center">
             <ChatBubbleLeftRightIcon height={65} width={70} fill={colorScheme === 'dark' ? '#474646' : '#d4d3d3'} />
             <Text className="mt-7 font-inter-bold text-[20px] text-[#706F6E] dark:text-[#B6B5B5]">
@@ -90,8 +124,29 @@ export default function ChatScreen() {
 
         ) : (
 
-          <View className="flex-1 justify-center items-center">
-          </View>
+          <FlatList
+            data={conversations}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+              <TouchableOpacity
+                onPress={() =>
+                  navigation.navigate('Conversation', {
+                    conversationId: item.id,
+                    name: item.name,
+                    participants: item.participants,
+                  })
+                }
+              >
+                <View className="flex-row items-center px-6 py-4 border-b-[1px] border-[#e0e0e0] dark:border-[#3d3d3d]">
+                  <View className="h-11 w-11 rounded-full bg-[#e0e0e0] dark:bg-[#3d3d3d] mr-3" />
+                  <View className="flex-1">
+                    <Text className="font-inter-semibold text-[15px] text-[#323131] dark:text-[#fcfcfc]">{item.name}</Text>
+                    <Text className="text-[13px] text-[#706F6E] dark:text-[#B6B5B5]" numberOfLines={1}>{item.lastMessage}</Text>
+                  </View>
+                </View>
+              </TouchableOpacity>
+            )}
+          />
 
         )}
 

--- a/Wisdom_expo/screens/chat/ConversationScreen.js
+++ b/Wisdom_expo/screens/chat/ConversationScreen.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { SafeAreaView as SafeTop, SafeAreaView as SafeBottom } from 'react-native-safe-area-context';
 import {
   SafeAreaView,
@@ -10,9 +10,14 @@ import {
   Pressable,
   FlatList,
   KeyboardAvoidingView,
+  Image,
+  Linking,
 } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import * as DocumentPicker from 'expo-document-picker';
+import RBSheet from 'react-native-raw-bottom-sheet';
 import { useColorScheme } from 'nativewind';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import {
   ChevronLeftIcon,
   EllipsisHorizontalIcon,
@@ -21,6 +26,19 @@ import {
 } from 'react-native-heroicons/outline';
 import { CheckIcon } from 'react-native-heroicons/solid';
 import { useTranslation } from 'react-i18next';
+import {
+  collection,
+  query,
+  orderBy,
+  onSnapshot,
+  addDoc,
+  doc,
+  setDoc,
+  serverTimestamp,
+} from 'firebase/firestore';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { db, storage } from '../../utils/firebase';
+import { getDataLocally } from '../../utils/asyncStorage';
 
 
 export default function ConversationScreen() {
@@ -32,64 +50,138 @@ export default function ConversationScreen() {
   const iconColor = colorScheme === 'dark' ? '#f2f2f2' : '#444343';
   const navigation = useNavigation();
   const flatListRef = useRef(null);
+  const attachSheet = useRef(null);
 
   // ---------------------------------------------------------------------------
-  // • STATE (mock)
+  // • STATE
   // ---------------------------------------------------------------------------
+  const route = useRoute();
+  const { conversationId, participants, name } = route.params;
   const [text, setText] = useState('');
-  const [messages, setMessages] = useState([
-    {
-      id: '1',
-      fromMe: true,
-      text: 'Hola!',
-      time: '11:20',
-      read: true,
-    },
-    
-    {
-      id: '2',
-      type: 'label',
-      text: 'Lorem ipsum',
-    },
-    {
-      id: '3',
-      fromMe: false,
-      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed',
-      time: '11:20',
-    }, 
-    {
-      id: '4',
-      fromMe: true,
-      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed',
-      time: '11:20',
-      read: true,
-    },
-    {
-      id: '5',
-      fromMe: true,
-      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed',
-      time: '11:20',
-      read: true,
-    },
-  ]);
+  const [messages, setMessages] = useState([]);
+  const [userId, setUserId] = useState(null);
+  const otherUserId = participants?.find((id) => id !== userId);
   const isLastOfStreak = (msgs, idx) =>
     idx === msgs.length - 1 || msgs[idx].fromMe !== msgs[idx + 1].fromMe;
+
+  useEffect(() => {
+    let unsub;
+    const init = async () => {
+      const userData = await getDataLocally('user');
+      if (!userData) return;
+      const user = JSON.parse(userData);
+      setUserId(user.id);
+      const q = query(
+        collection(db, 'conversations', conversationId, 'messages'),
+        orderBy('createdAt')
+      );
+      unsub = onSnapshot(q, (snap) => {
+        const data = snap.docs.map((d) => {
+          const msg = d.data();
+          return {
+            id: d.id,
+            fromMe: msg.senderId === user.id,
+            ...msg,
+          };
+        });
+        setMessages(data);
+        flatListRef.current?.scrollToEnd({ animated: true });
+      });
+    };
+    init();
+    return () => unsub && unsub();
+  }, [conversationId]);
 
   // ---------------------------------------------------------------------------
   // • ACTIONS
   // ---------------------------------------------------------------------------
-  const handleSend = () => {
+  const handleSend = async () => {
     if (!text.trim()) return;
     const newMsg = {
-      id: Date.now().toString(),
-      fromMe: true,
+      senderId: userId,
+      type: 'text',
       text: text.trim(),
-      time: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-      read: false,
+      createdAt: serverTimestamp(),
     };
-    setMessages((prev) => [...prev, newMsg]);
+    await addDoc(collection(db, 'conversations', conversationId, 'messages'), newMsg);
+    await setDoc(
+      doc(db, 'conversations', conversationId),
+      {
+        participants,
+        name,
+        lastMessage: text.trim(),
+        updatedAt: serverTimestamp(),
+      },
+      { merge: true }
+    );
     setText('');
-    flatListRef.current?.scrollToEnd({ animated: true });
+  };
+
+
+  const handleImagePick = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.7,
+    });
+    if (!result.canceled) {
+      const asset = result.assets[0];
+      const response = await fetch(asset.uri);
+      const blob = await response.blob();
+      const fileRef = ref(
+        storage,
+        `chat/${conversationId}/${Date.now()}_${asset.fileName || 'image.jpg'}`
+      );
+      await uploadBytes(fileRef, blob);
+      const downloadURL = await getDownloadURL(fileRef);
+      await addDoc(collection(db, 'conversations', conversationId, 'messages'), {
+        senderId: userId,
+        type: 'image',
+        uri: downloadURL,
+        name: asset.fileName || 'image',
+        createdAt: serverTimestamp(),
+      });
+      await setDoc(
+        doc(db, 'conversations', conversationId),
+        {
+          participants,
+          name,
+          lastMessage: '📷',
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true }
+      );
+    }
+  };
+
+  const handleFilePick = async () => {
+    const result = await DocumentPicker.getDocumentAsync({});
+    if (result.type === 'success') {
+      const response = await fetch(result.uri);
+      const blob = await response.blob();
+      const fileRef = ref(
+        storage,
+        `chat/${conversationId}/${Date.now()}_${result.name}`
+      );
+      await uploadBytes(fileRef, blob);
+      const downloadURL = await getDownloadURL(fileRef);
+      await addDoc(collection(db, 'conversations', conversationId, 'messages'), {
+        senderId: userId,
+        type: 'file',
+        uri: downloadURL,
+        name: result.name,
+        createdAt: serverTimestamp(),
+      });
+      await setDoc(
+        doc(db, 'conversations', conversationId),
+        {
+          participants,
+          name,
+          lastMessage: '📎',
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true }
+      );
+    }
   };
 
   // ---------------------------------------------------------------------------
@@ -103,31 +195,80 @@ export default function ConversationScreen() {
             {item.text}
           </Text>
         </View>
-        
+
       );
     }
-  
-    const lastOfStreak = isLastOfStreak(messages, index); 
-  
+
+    const lastOfStreak = isLastOfStreak(messages, index);
+
     const bubbleBase =
       'rounded-2xl px-4 py-2 max-w-[70%] my-[2] flex-row items-end';
-  
-    // Común a todos los propios / ajenos
+
     const common =
       item.fromMe
         ? 'self-end bg-[#FCFCFC] dark:bg-[#323131]'
         : 'self-start bg-[#D4D4D3] dark:bg-[#3d3d3d]';
-  
-    // Sólo quitamos esquina exterior si es el último de la racha
+
     const corner =
       item.fromMe
         ? lastOfStreak ? ' rounded-br' : ''
         : lastOfStreak ? ' rounded-bl' : '';
-  
+
     const fromMeStyles = common + corner;
-  
+
     const textColor = 'text-[15px] font-medium text-[#515150] dark:text-[#d4d4d3]';
-  
+
+    if (item.type === 'image') {
+      return (
+        <View>
+          <View className={`${bubbleBase} ${fromMeStyles}`}>
+            <Image source={{ uri: item.uri }} className="w-40 h-40 rounded-lg" />
+          </View>
+          {lastOfStreak && (
+            <View
+              className={`${item.fromMe ? 'justify-end pr-1' : 'justify-start pl-1'} flex-row items-center mt-0.5 mb-2`}
+            >
+              {item.fromMe && item.read && (
+                <CheckIcon height={14} width={14} color="#9ca3af" />
+              )}
+              <Text className="text-[13px] text-[#b6b5b5] dark:text-[#706f6e] ml-1">
+                {item.createdAt &&
+                  new Date(item.createdAt.seconds * 1000).toLocaleTimeString([], {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+              </Text>
+            </View>
+          )}
+        </View>
+      );
+    }
+
+    if (item.type === 'file') {
+      return (
+        <View>
+          <Pressable onPress={() => Linking.openURL(item.uri)} className={`${bubbleBase} ${fromMeStyles}`}> 
+            <Text className={textColor}>{item.name}</Text>
+          </Pressable>
+          {lastOfStreak && (
+            <View
+              className={`${item.fromMe ? 'justify-end pr-1' : 'justify-start pl-1'} flex-row items-center mt-0.5 mb-2`}
+            >
+              {item.fromMe && item.read && (
+                <CheckIcon height={14} width={14} color="#9ca3af" />
+              )}
+              <Text className="text-[13px] text-[#b6b5b5] dark:text-[#706f6e] ml-1">
+                {item.createdAt &&
+                  new Date(item.createdAt.seconds * 1000).toLocaleTimeString([], {
+                    hour: '2-digit',
+                    minute: '2-digit',
+                  })}
+              </Text>
+            </View>
+          )}
+        </View>
+      );
+    }
     return (
       <View>                                         {/* ← contenedor nuevo */}
         <View className={`${bubbleBase} ${fromMeStyles}`}>
@@ -147,7 +288,11 @@ export default function ConversationScreen() {
               <CheckIcon height={14} width={14} color="#9ca3af" />
             )}
             <Text className="text-[13px] text-[#b6b5b5] dark:text-[#706f6e] ml-1">
-              {item.time}
+              {item.createdAt &&
+                new Date(item.createdAt.seconds * 1000).toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                })}
             </Text>
           </View>
         )}
@@ -178,7 +323,7 @@ export default function ConversationScreen() {
 
         <View className="h-8 w-8 rounded-full bg-gray-300 dark:bg-[#3d3d3d] mx-2" />
         <Text className="flex-1 text-base font-inter-semibold text-[#444343] dark:text-[#f2f2f2]">
-          Nom Cognom
+          {name}
         </Text>
 
         <Pressable hitSlop={8} className="p-1">
@@ -211,6 +356,7 @@ export default function ConversationScreen() {
         >
           {/* Attachment – bolita aparte */}
           <Pressable
+            onPress={() => attachSheet.current.open()}
             hitSlop={8}
             className="h-11 w-11 rounded-full              /* idéntico alto-ancho */
                       items-center justify-center
@@ -263,7 +409,31 @@ export default function ConversationScreen() {
         </View>
 
       </KeyboardAvoidingView>
-    
+
+      <RBSheet
+        ref={attachSheet}
+        height={160}
+        openDuration={200}
+        closeDuration={200}
+        customStyles={{
+          container: {
+            borderTopRightRadius: 25,
+            borderTopLeftRadius: 25,
+            backgroundColor: colorScheme === 'dark' ? '#323131' : '#fcfcfc',
+          },
+          draggableIcon: { backgroundColor: colorScheme === 'dark' ? '#3d3d3d' : '#f2f2f2' },
+        }}
+      >
+        <View className="p-4 space-y-4">
+          <Pressable onPress={handleImagePick} className="py-2">
+            <Text className="text-base font-inter-medium text-[#444343] dark:text-[#f2f2f2]">Choose image</Text>
+          </Pressable>
+          <Pressable onPress={handleFilePick} className="py-2">
+            <Text className="text-base font-inter-medium text-[#444343] dark:text-[#f2f2f2]">Choose file</Text>
+          </Pressable>
+        </View>
+      </RBSheet>
+
       </View>
   );
 }

--- a/Wisdom_expo/utils/firebase.js
+++ b/Wisdom_expo/utils/firebase.js
@@ -1,0 +1,17 @@
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
+
+const firebaseConfig = {
+  apiKey: 'AIzaSyBMRVaUV1DSj6rpPTg8c01YEJdnTK4A52A',
+  authDomain: 'wisdom-6475e.firebaseapp.com',
+  projectId: 'wisdom-6475e',
+  storageBucket: 'wisdom-6475e.appspot.com',
+  messagingSenderId: '1059564042301',
+  appId: '1:1059564042301:web:69e6ac37592e920f151254',
+};
+
+const app = initializeApp(firebaseConfig);
+export const db = getFirestore(app);
+export const storage = getStorage(app);
+export default app;


### PR DESCRIPTION
## Summary
- add Firebase initialization helper
- fetch conversation list from Firestore in `ChatScreen`
- load and send messages through Firestore in `ConversationScreen`
- upload images and files to Firebase Storage

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68417f618480832b930e4c644e205a62