### PR TITLE
Fix login persistence across app restarts

### DIFF
--- a/Wisdom_expo/screens/chat/ChatScreen.js
+++ b/Wisdom_expo/screens/chat/ChatScreen.js
@@ -33,7 +33,7 @@ export default function ChatScreen() {
         console.log(userData);
 
         // Comprobar si userData indica que no hay usuario
-        if (userData === '{"userToken":false}') {
+        if (userData === '{"token":false}') {
           navigation.reset({
             index: 0,
             routes: [{ name: 'GetStarted' }],

--- a/Wisdom_expo/screens/favorites/FavoritesScreen.js
+++ b/Wisdom_expo/screens/favorites/FavoritesScreen.js
@@ -26,10 +26,10 @@
           console.log(userData);
   
           // Comprobar si userData indica que no hay usuario
-          if (userData === '{"userToken":false}') {
+          if (userData === '{"token":false}') {
             navigation.reset({
               index: 0,
-              routes: [{ name: 'GetStarted' }], 
+              routes: [{ name: 'GetStarted' }],
             });
           }
         };

--- a/Wisdom_expo/screens/home/ServiceProfileScreen.js
+++ b/Wisdom_expo/screens/home/ServiceProfileScreen.js
@@ -92,10 +92,10 @@ export default function ServiceProfileScreen() {
     console.log(userData);
 
     // Comprobar si userData indica que no hay usuario
-    if (userData === '{"userToken":false}') {
+    if (userData === '{"token":false}') {
       navigation.reset({
         index: 0,
-        routes: [{ name: 'GetStarted' }], 
+        routes: [{ name: 'GetStarted' }],
       });
     } else {
       openSheetWithInput(700); setIsAddingDate(true)

--- a/Wisdom_expo/screens/professional/SettingsProScreen.js
+++ b/Wisdom_expo/screens/professional/SettingsProScreen.js
@@ -65,10 +65,10 @@ export default function SettingsScreen() {
         console.log(userData);
 
         // Comprobar si userData indica que no hay usuario
-        if (userData === '{"userToken":false}') {
+        if (userData === '{"token":false}') {
           navigation.reset({
             index: 0,
-            routes: [{ name: 'GetStarted' }], 
+            routes: [{ name: 'GetStarted' }],
           });
         }
       };
@@ -78,7 +78,7 @@ export default function SettingsScreen() {
   );
 
   const logOut = async () => {
-    let emptyUser = { userToken: false}
+    let emptyUser = { token: false}
     await storeDataLocally('user', JSON.stringify(emptyUser));
     navigation.navigate('GetStarted');
   };

--- a/Wisdom_expo/screens/services/ServicesScreen.js
+++ b/Wisdom_expo/screens/services/ServicesScreen.js
@@ -34,10 +34,10 @@ export default function ServicesScreen() {
         console.log(userData);
 
         // Comprobar si userData indica que no hay usuario
-        if (userData === '{"userToken":false}') {
+        if (userData === '{"token":false}') {
           navigation.reset({
             index: 0,
-            routes: [{ name: 'GetStarted' }], 
+            routes: [{ name: 'GetStarted' }],
           });
         }
       };

--- a/Wisdom_expo/screens/settings/CreateService1Screen.js
+++ b/Wisdom_expo/screens/settings/CreateService1Screen.js
@@ -23,10 +23,10 @@ export default function CreateService1Screen() {
         console.log(userData);
 
         // Comprobar si userData indica que no hay usuario
-        if (userData === '{"userToken":false}') {
+        if (userData === '{"token":false}') {
           navigation.reset({
             index: 0,
-            routes: [{ name: 'GetStarted' }], 
+            routes: [{ name: 'GetStarted' }],
           });
         }
       };

--- a/Wisdom_expo/screens/settings/SettingsScreen.js
+++ b/Wisdom_expo/screens/settings/SettingsScreen.js
@@ -76,10 +76,10 @@ export default function SettingsScreen() {
         console.log(userData);
 
         // Comprobar si userData indica que no hay usuario
-        if (userData === '{"userToken":false}') {
+        if (userData === '{"token":false}') {
           navigation.reset({
             index: 0,
-            routes: [{ name: 'GetStarted' }], 
+            routes: [{ name: 'GetStarted' }],
           });
         }
       };
@@ -89,7 +89,7 @@ export default function SettingsScreen() {
   );
 
   const logOut = async () => {
-    let emptyUser = { userToken: false}
+    let emptyUser = { token: false}
     await storeDataLocally('user', JSON.stringify(emptyUser));
     navigation.navigate('GetStarted');
   };

--- a/Wisdom_expo/screens/start/LoadingScreen.js
+++ b/Wisdom_expo/screens/start/LoadingScreen.js
@@ -29,13 +29,13 @@ export default function SettingsScreen() {
       
       if (userData) {
         const user = JSON.parse(userData);
-        setToken(user.userToken);
+        setToken(user.token);
         let language = user.selectedLanguage;
         if (language) {
           i18n.changeLanguage(language);
         };
         setTimeout(() => {
-          if (user.userToken) {
+          if (user.token) {
             navigation.navigate('HomeScreen');
           } else {
             navigation.navigate('GetStarted');

--- a/Wisdom_expo/screens/start/WelcomeVideoScreen.js
+++ b/Wisdom_expo/screens/start/WelcomeVideoScreen.js
@@ -80,8 +80,8 @@ const WelcomeVideoScreen = () => {
       console.log(userData)
       if (userData) {
         const user = JSON.parse(userData);
-        setToken(user.userToken);    
-        if (user.userToken) {
+        setToken(user.token);
+        if (user.token) {
           navigation.navigate('Loading');
         } else {
           setShowSkip(true);


### PR DESCRIPTION
## Summary
- use `token` property consistently for stored user session
- check for logged-out state using `{ token: false }`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684eb08cc8d4832b900880a596a1ee72