### PR TITLE
Implement message status icons

### DIFF
--- a/Wisdom_expo/assets/DoubleCheck.tsx
+++ b/Wisdom_expo/assets/DoubleCheck.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import Svg, { Path } from "react-native-svg";
-const SVGComponent = (props) => (
+
+const SVGComponent = ({ color = "#323131", ...props }) => (
   <Svg
     width={13}
     height={7}
@@ -11,22 +12,23 @@ const SVGComponent = (props) => (
   >
     <Path
       d="M1 4.19849L2.57135 5.76983"
-      stroke="#323131"
+      stroke={color}
       strokeWidth={1.5}
       strokeLinecap="round"
     />
     <Path
       d="M2.80127 6L7.80127 1"
-      stroke="#323131"
+      stroke={color}
       strokeWidth={1.5}
       strokeLinecap="round"
     />
     <Path
       d="M6.72949 6L11.7295 1"
-      stroke="#323131"
+      stroke={color}
       strokeWidth={1.5}
       strokeLinecap="round"
     />
   </Svg>
 );
+
 export default SVGComponent;

--- a/Wisdom_expo/screens/chat/ConversationScreen.js
+++ b/Wisdom_expo/screens/chat/ConversationScreen.js
@@ -53,6 +53,8 @@ export default function ConversationScreen() {
   const { t } = useTranslation();
   const { colorScheme } = useColorScheme();
   const iconColor = colorScheme === 'dark' ? '#f2f2f2' : '#444343';
+  const statusReadColor = colorScheme === 'dark' ? '#d4d4d3' : '#515150';
+  const statusUnreadColor = '#9ca3af';
   const navigation = useNavigation();
   const flatListRef = useRef(null);
   const attachSheet = useRef(null);
@@ -260,8 +262,12 @@ export default function ConversationScreen() {
             <View
               className={`${item.fromMe ? 'justify-end pr-1' : 'justify-start pl-1'} flex-row items-center mt-0.5 mb-2`}
             >
-              {item.fromMe && item.read && (
-                <Check height={14} width={14} color="#9ca3af" strokeWidth={3}/>
+              {item.fromMe && (
+                item.read ? (
+                  <DoubleCheck height={14} width={14} color={statusReadColor} />
+                ) : (
+                  <Check height={14} width={14} color={statusUnreadColor} strokeWidth={3} />
+                )
               )}
               <Text className="text-[13px] text-[#b6b5b5] dark:text-[#706f6e] ml-1">
                 {item.createdAt &&
@@ -286,8 +292,12 @@ export default function ConversationScreen() {
             <View
               className={`${item.fromMe ? 'justify-end pr-1' : 'justify-start pl-1'} flex-row items-center mt-0.5 mb-2`}
             >
-              {item.fromMe && item.read && (
-                <Check height={14} width={14} color="#9ca3af" strokeWidth={3}/>
+              {item.fromMe && (
+                item.read ? (
+                  <DoubleCheck height={14} width={14} color={statusReadColor} />
+                ) : (
+                  <Check height={14} width={14} color={statusUnreadColor} strokeWidth={3} />
+                )
               )}
               <Text className="text-[13px] text-[#b6b5b5] dark:text-[#706f6e] ml-1">
                 {item.createdAt &&
@@ -317,8 +327,12 @@ export default function ConversationScreen() {
               ${item.fromMe ? 'justify-end pr-1' : 'justify-start pl-1'}
             `}
           >
-            {item.fromMe && item.read && (
-              <Check height={14} width={14} color="#9ca3af" strokeWidth={3}/>
+            {item.fromMe && (
+              item.read ? (
+                <DoubleCheck height={14} width={14} color={statusReadColor} />
+              ) : (
+                <Check height={14} width={14} color={statusUnreadColor} strokeWidth={3} />
+              )
             )}
             <Text className="text-[13px] text-[#b6b5b5] dark:text-[#706f6e] ml-1">
               {item.createdAt &&


### PR DESCRIPTION
## Summary
- allow passing color to `DoubleCheck` SVG
- show single or double check depending on message status

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685dbba87c84832bafac7bf3c5030db7