### PR TITLE
Add inactive booking state and delete option

### DIFF
--- a/Wisdom_expo/languages/ar.json
+++ b/Wisdom_expo/languages/ar.json
@@ -286,6 +286,10 @@
     "select_a_time": "اختر وقتًا",
     "select_a_duration": "اختر المدّة",
     "date": "تاريخ",
-    "description": "الوصف"
+    "description": "الوصف",
+    "delete_booking": "حذف الحجز",
+    "booking_canceled": "تم إلغاء الحجز",
+    "booking_rejected": "تم رفض الحجز",
+    "booking_expired": "انتهى تاريخ البدء"
   }
 }

--- a/Wisdom_expo/languages/ca.json
+++ b/Wisdom_expo/languages/ca.json
@@ -286,6 +286,10 @@
     "select_a_time": "Selecciona una hora",
     "select_a_duration": "Selecciona una durada",
     "date": "Data",
-    "description": "Descripció"
+    "description": "Descripció",
+    "delete_booking": "Eliminar reserva",
+    "booking_canceled": "Reserva cancel·lada",
+    "booking_rejected": "Reserva rebutjada",
+    "booking_expired": "La data d'inici ha passat"
   }
 }

--- a/Wisdom_expo/languages/en.json
+++ b/Wisdom_expo/languages/en.json
@@ -286,6 +286,10 @@
     "select_a_time": "Select a time",
     "select_a_duration": "Select a duration",
     "date": "Date",
-    "description": "Description"
+    "description": "Description",
+    "delete_booking": "Delete booking",
+    "booking_canceled": "Booking canceled",
+    "booking_rejected": "Booking rejected",
+    "booking_expired": "Booking date has passed"
   }
 }

--- a/Wisdom_expo/languages/es.json
+++ b/Wisdom_expo/languages/es.json
@@ -286,6 +286,10 @@
     "select_a_time": "Selecciona una hora",
     "select_a_duration": "Selecciona una duración",
     "date": "Fecha",
-    "description": "Descripción"
+    "description": "Descripción",
+    "delete_booking": "Eliminar reserva",
+    "booking_canceled": "Reserva cancelada",
+    "booking_rejected": "Reserva rechazada",
+    "booking_expired": "La fecha de inicio ha pasado"
   }
 }

--- a/Wisdom_expo/languages/fr.json
+++ b/Wisdom_expo/languages/fr.json
@@ -286,6 +286,10 @@
     "select_a_time": "Sélectionnez une heure",
     "select_a_duration": "Sélectionnez une durée",
     "date": "Date",
-    "description": "Description"
+    "description": "Description",
+    "delete_booking": "Supprimer la réservation",
+    "booking_canceled": "Réservation annulée",
+    "booking_rejected": "Réservation rejetée",
+    "booking_expired": "La date de début est passée"
   }
 }

--- a/Wisdom_expo/languages/zh.json
+++ b/Wisdom_expo/languages/zh.json
@@ -286,6 +286,10 @@
     "select_a_time": "选择时间",
     "select_a_duration": "选择时长",
     "date": "日期",
-    "description": "描述"
+    "description": "描述",
+    "delete_booking": "删除预订",
+    "booking_canceled": "预订已取消",
+    "booking_rejected": "预订已拒绝",
+    "booking_expired": "开始日期已过"
   }
 }


### PR DESCRIPTION
## Summary
- add messages for booking state translations
- disable actions when booking is canceled, rejected or expired
- show non-interactive locked button with short status message
- allow deleting booking via new API endpoint

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e687a7c40832b8cb06497666e06aa