### PR TITLE
Add waiting payment state for professionals

### DIFF
--- a/Wisdom_expo/languages/ar.json
+++ b/Wisdom_expo/languages/ar.json
@@ -290,6 +290,7 @@
     "delete_booking": "حذف الحجز",
     "service_completed": "الخدمة منتهية",
     "final_payment": "الدفع النهائي",
+    "waiting_final_payment": "في انتظار الدفعة النهائية",
     "booking_canceled": "تم إلغاء الحجز",
     "booking_rejected": "تم رفض الحجز",
     "booking_expired": "انتهى تاريخ البدء",

--- a/Wisdom_expo/languages/ca.json
+++ b/Wisdom_expo/languages/ca.json
@@ -290,6 +290,7 @@
     "delete_booking": "Eliminar reserva",
     "service_completed": "Servei finalitzat",
     "final_payment": "Pagament final",
+    "waiting_final_payment": "Esperant pagament final",
     "booking_canceled": "Reserva cancel·lada",
     "booking_rejected": "Reserva rebutjada",
     "booking_expired": "La data d'inici ha passat",

--- a/Wisdom_expo/languages/en.json
+++ b/Wisdom_expo/languages/en.json
@@ -290,6 +290,7 @@
     "delete_booking": "Delete booking",
     "service_completed": "Service completed",
     "final_payment": "Final payment",
+    "waiting_final_payment": "Waiting for final payment",
     "booking_canceled": "Booking canceled",
     "booking_rejected": "Booking rejected",
     "booking_expired": "Booking date has passed",

--- a/Wisdom_expo/languages/es.json
+++ b/Wisdom_expo/languages/es.json
@@ -290,6 +290,7 @@
     "delete_booking": "Eliminar reserva",
     "service_completed": "Servicio finalizado",
     "final_payment": "Pago final",
+    "waiting_final_payment": "Esperando pago final",
     "booking_canceled": "Reserva cancelada",
     "booking_rejected": "Reserva rechazada",
     "booking_expired": "La fecha de inicio ha pasado",

--- a/Wisdom_expo/languages/fr.json
+++ b/Wisdom_expo/languages/fr.json
@@ -290,6 +290,7 @@
     "delete_booking": "Supprimer la réservation",
     "service_completed": "Service terminé",
     "final_payment": "Paiement final",
+    "waiting_final_payment": "En attente du paiement final",
     "booking_canceled": "Réservation annulée",
     "booking_rejected": "Réservation rejetée",
     "booking_expired": "La date de début est passée",

--- a/Wisdom_expo/languages/zh.json
+++ b/Wisdom_expo/languages/zh.json
@@ -290,6 +290,7 @@
     "delete_booking": "删除预订",
     "service_completed": "服务完成",
     "final_payment": "最终付款",
+    "waiting_final_payment": "等待最终付款",
     "booking_canceled": "预订已取消",
     "booking_rejected": "预订已拒绝",
     "booking_expired": "开始日期已过",

--- a/Wisdom_expo/screens/booking/BookingDetailsScreen.js
+++ b/Wisdom_expo/screens/booking/BookingDetailsScreen.js
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
 import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native';
-import { XMarkIcon, LockClosedIcon, ChevronRightIcon, XCircleIcon } from 'react-native-heroicons/outline';
+import { XMarkIcon, LockClosedIcon, ChevronRightIcon, XCircleIcon, ClockIcon } from 'react-native-heroicons/outline';
 import { Calendar } from 'react-native-calendars';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import Slider from '@react-native-community/slider';
@@ -1047,21 +1047,30 @@ export default function BookingDetailsScreen() {
           ) : (
             <>
               {showServiceFinished ? (
-                <TouchableOpacity
-                  onPress={handleFinalPayment}
-                  className='mt-2 mb-2 bg-[#323131] dark:bg-[#fcfcfc] rounded-full items-center py-[18px]'
-                  style={{
-                    opacity: 1,
-                    shadowColor: colorScheme === 'dark' ? '#fcfcfc' : '#323131',
-                    shadowOffset: { width: 0, height: 0 },
-                    shadowOpacity: 0.6,
-                    shadowRadius: 10,
-                    elevation: 10,
-                  }}>
-                  <Text className='font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]'>
-                    {t('final_payment')}
-                  </Text>
-                </TouchableOpacity>
+                role === 'pro' ? (
+                  <TouchableOpacity disabled className='mt-2 flex-row bg-[#3D3D3D] dark:bg-[#E0E0E0] rounded-full items-center justify-center py-[18px] opacity-[.5]'>
+                    <ClockIcon strokeWidth={2.1} size={18} color={colorScheme === 'dark' ? '#323131' : '#fcfcfc'} />
+                    <Text className='ml-2 font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]'>
+                      {t('waiting_final_payment')}
+                    </Text>
+                  </TouchableOpacity>
+                ) : (
+                  <TouchableOpacity
+                    onPress={handleFinalPayment}
+                    className='mt-2 mb-2 bg-[#323131] dark:bg-[#fcfcfc] rounded-full items-center py-[18px]'
+                    style={{
+                      opacity: 1,
+                      shadowColor: colorScheme === 'dark' ? '#fcfcfc' : '#323131',
+                      shadowOffset: { width: 0, height: 0 },
+                      shadowOpacity: 0.6,
+                      shadowRadius: 10,
+                      elevation: 10,
+                    }}>
+                    <Text className='font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]'>
+                      {t('final_payment')}
+                    </Text>
+                  </TouchableOpacity>
+                )
               ) : (
                 <TouchableOpacity onPress={startChat} className='mt-2 bg-[#323131] dark:bg-[#fcfcfc] rounded-full items-center py-[18px]'>
                   <Text className='font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]'>


### PR DESCRIPTION
## Summary
- show disabled Waiting final payment button for professionals
- localize new waiting_final_payment string in all languages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685fe5678df4832b9360378075672abd