### PR TITLE
Add reply option to message action sheet

### DIFF
--- a/Wisdom_expo/languages/ar.json
+++ b/Wisdom_expo/languages/ar.json
@@ -285,6 +285,7 @@
     "confirm_cancel_booking": "هل أنت متأكد أنك تريد إلغاء هذا الحجز؟",
     "reject": "رفض",
     "edit": "تعديل",
+    "reply": "رد",
     "copy": "نسخ",
     "select_a_time": "اختر وقتًا",
     "select_a_duration": "اختر المدّة",

--- a/Wisdom_expo/languages/ca.json
+++ b/Wisdom_expo/languages/ca.json
@@ -285,6 +285,7 @@
     "confirm_cancel_booking": "Segur que vols cancel·lar aquesta reserva?",
     "reject": "Rebutjar",
     "edit": "Editar",
+    "reply": "Respondre",
     "copy": "Copiar",
     "select_a_time": "Selecciona una hora",
     "select_a_duration": "Selecciona una durada",

--- a/Wisdom_expo/languages/en.json
+++ b/Wisdom_expo/languages/en.json
@@ -285,6 +285,7 @@
     "confirm_cancel_booking": "Are you sure you want to cancel this booking?",
     "reject": "Reject",
     "edit": "Edit",
+    "reply": "Reply",
     "copy": "Copy",
     "select_a_time": "Select a time",
     "select_a_duration": "Select a duration",

--- a/Wisdom_expo/languages/es.json
+++ b/Wisdom_expo/languages/es.json
@@ -285,6 +285,7 @@
     "confirm_cancel_booking": "¿Seguro que deseas cancelar esta reserva?",
     "reject": "Rechazar",
     "edit": "Editar",
+    "reply": "Responder",
     "copy": "Copiar",
     "select_a_time": "Selecciona una hora",
     "select_a_duration": "Selecciona una duración",

--- a/Wisdom_expo/languages/fr.json
+++ b/Wisdom_expo/languages/fr.json
@@ -285,6 +285,7 @@
     "confirm_cancel_booking": "Êtes-vous sûr de vouloir annuler cette réservation ?",
     "reject": "Rejeter",
     "edit": "Modifier",
+    "reply": "Répondre",
     "copy": "Copier",
     "select_a_time": "Sélectionnez une heure",
     "select_a_duration": "Sélectionnez une durée",

--- a/Wisdom_expo/languages/zh.json
+++ b/Wisdom_expo/languages/zh.json
@@ -285,6 +285,7 @@
     "confirm_cancel_booking": "确定要取消此预订吗？",
     "reject": "拒绝",
     "edit": "编辑",
+    "reply": "回复",
     "copy": "复制",
     "select_a_time": "选择时间",
     "select_a_duration": "选择时长",

--- a/Wisdom_expo/screens/chat/ConversationScreen.js
+++ b/Wisdom_expo/screens/chat/ConversationScreen.js
@@ -29,7 +29,7 @@ import {
   XMarkIcon,
   DocumentDuplicateIcon,
 } from 'react-native-heroicons/outline';
-import { MoreHorizontal, Image as ImageIcon, Folder, Check, Edit2, Trash2, File } from "react-native-feather";
+import { MoreHorizontal, Image as ImageIcon, Folder, Check, Edit2, Trash2, File, CornerUpLeft } from "react-native-feather";
 import { useTranslation } from 'react-i18next';
 import {
   collection,
@@ -258,6 +258,12 @@ export default function ConversationScreen() {
     msgSheet.current.close();
   };
 
+  const handleReplyMessage = () => {
+    if (!selectedMsg) return;
+    setReplyTo(selectedMsg);
+    msgSheet.current.close();
+  };
+
   // ---------------------------------------------------------------------------
   // • RENDER HELPERS
   // ---------------------------------------------------------------------------
@@ -328,7 +334,7 @@ export default function ConversationScreen() {
             }
           }}
         >
-          <Pressable onLongPress={() => { setSelectedMsg(item); msgSheet.current.open(); }}>
+          <Pressable onLongPress={() => { setSelectedMsg(item); setTimeout(() => msgSheet.current.open(), 0); }}>
             {content}
             {lastOfStreak && (
               <View
@@ -387,7 +393,7 @@ export default function ConversationScreen() {
             }
           }}
         >
-          <Pressable onLongPress={() => { setSelectedMsg(item); msgSheet.current.open(); }}>
+          <Pressable onLongPress={() => { setSelectedMsg(item); setTimeout(() => msgSheet.current.open(), 0); }}>
             {content}
             {lastOfStreak && (
               <View
@@ -446,7 +452,7 @@ export default function ConversationScreen() {
           }
         }}
       >
-        <Pressable onLongPress={() => { setSelectedMsg(item); msgSheet.current.open(); }}>
+        <Pressable onLongPress={() => { setSelectedMsg(item); setTimeout(() => msgSheet.current.open(), 0); }}>
           {content}
 
           {lastOfStreak && (
@@ -642,7 +648,7 @@ export default function ConversationScreen() {
 
       <RBSheet
         ref={msgSheet}
-        height={200}
+        height={selectedMsg?.fromMe ? 260 : 160}
         openDuration={200}
         closeDuration={200}
         customStyles={{
@@ -667,6 +673,10 @@ export default function ConversationScreen() {
               </TouchableOpacity>
             </>
           )}
+          <TouchableOpacity onPress={handleReplyMessage} className="py-1 flex-row justify-start items-center ">
+            <CornerUpLeft height={23} width={23} color={iconColor} strokeWidth={2} />
+            <Text className="ml-3 text-base font-inter-medium text-[#444343] dark:text-[#f2f2f2]">{t('reply')}</Text>
+          </TouchableOpacity>
           <TouchableOpacity onPress={handleCopyMessage} className="py-1 flex-row justify-start items-center ">
             <DocumentDuplicateIcon height={23} width={23} color={iconColor} strokeWidth={2} />
             <Text className="ml-3 text-base font-inter-medium text-[#444343] dark:text-[#f2f2f2]">{t('copy')}</Text>


### PR DESCRIPTION
## Summary
- allow replying to a message from the bottom sheet
- adjust bottom sheet height based on message ownership
- add CornerUpLeft icon for reply
- update translations with new `reply` key

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68655ec438d0832bba43a9e9232a4c52