### PR TITLE
Add missing translations

### DIFF
--- a/Wisdom_expo/languages/ar.json
+++ b/Wisdom_expo/languages/ar.json
@@ -306,6 +306,12 @@
     "skip": "تخطي",
     "rate_service": "قيّم الخدمة",
     "write_comment": "اكتب تعليقًا...",
-    "submit_review": "إرسال المراجعة"
+    "submit_review": "إرسال المراجعة",
+    "image": "صورة",
+    "images": "صور",
+    "file": "ملف",
+    "choose_image": "اختر صورة",
+    "choose_file": "اختر ملف",
+    "you": "أنت"
   }
 }

--- a/Wisdom_expo/languages/ca.json
+++ b/Wisdom_expo/languages/ca.json
@@ -306,6 +306,12 @@
     "skip": "Saltar",
     "rate_service": "Valora el servei",
     "write_comment": "Escriu un comentari...",
-    "submit_review": "Enviar ressenya"
+    "submit_review": "Enviar ressenya",
+    "image": "Imatge",
+    "images": "Imatges",
+    "file": "Fitxer",
+    "choose_image": "Triar imatge",
+    "choose_file": "Triar fitxer",
+    "you": "Tu"
   }
 }

--- a/Wisdom_expo/languages/en.json
+++ b/Wisdom_expo/languages/en.json
@@ -306,6 +306,12 @@
     "skip": "Skip",
     "rate_service": "Rate the service",
     "write_comment": "Write a comment...",
-    "submit_review": "Submit review"
+    "submit_review": "Submit review",
+    "image": "Image",
+    "images": "Images",
+    "file": "File",
+    "choose_image": "Choose image",
+    "choose_file": "Choose file",
+    "you": "You"
   }
 }

--- a/Wisdom_expo/languages/es.json
+++ b/Wisdom_expo/languages/es.json
@@ -306,6 +306,12 @@
     "skip": "Saltar",
     "rate_service": "Valora el servicio",
     "write_comment": "Escribe un comentario...",
-    "submit_review": "Enviar reseña"
+    "submit_review": "Enviar reseña",
+    "image": "Imagen",
+    "images": "Imágenes",
+    "file": "Archivo",
+    "choose_image": "Elegir imagen",
+    "choose_file": "Elegir archivo",
+    "you": "Tú"
   }
 }

--- a/Wisdom_expo/languages/fr.json
+++ b/Wisdom_expo/languages/fr.json
@@ -306,6 +306,12 @@
     "skip": "Ignorer",
     "rate_service": "Évaluez le service",
     "write_comment": "Écrire un commentaire...",
-    "submit_review": "Envoyer l'avis"
+    "submit_review": "Envoyer l'avis",
+    "image": "Image",
+    "images": "Images",
+    "file": "Fichier",
+    "choose_image": "Choisir une image",
+    "choose_file": "Choisir un fichier",
+    "you": "Vous"
   }
 }

--- a/Wisdom_expo/languages/zh.json
+++ b/Wisdom_expo/languages/zh.json
@@ -306,6 +306,12 @@
     "skip": "跳过",
     "rate_service": "为服务评分",
     "write_comment": "写下评论...",
-    "submit_review": "提交评价"
+    "submit_review": "提交评价",
+    "image": "图片",
+    "images": "图片",
+    "file": "文件",
+    "choose_image": "选择图片",
+    "choose_file": "选择文件",
+    "you": "你"
   }
 }

--- a/Wisdom_expo/screens/chat/ChatImageViewerScreen.js
+++ b/Wisdom_expo/screens/chat/ChatImageViewerScreen.js
@@ -46,7 +46,7 @@ export default function ChatImageViewerScreen() {
 
           <View className="flex-[2] justify-center items-center  ">
             <Text className='font-inter-bold text-[17px] text-[#444343] dark:text-[#f2f2f2]'>
-                Images
+                {t('images')}
             </Text>
           </View>
 

--- a/Wisdom_expo/screens/chat/ConversationScreen.js
+++ b/Wisdom_expo/screens/chat/ConversationScreen.js
@@ -230,7 +230,7 @@ export default function ConversationScreen() {
           {
             participants,
             name,
-            lastMessage: attachment.type.startsWith('image') ? 'Image' : 'File',
+          lastMessage: attachment.type.startsWith('image') ? t('image') : t('file'),
             updatedAt: serverTimestamp(),
             lastMessageSenderId: userId,
             readBy: arrayUnion(userId),   // arrayUnion en vez de arrayRemove
@@ -368,10 +368,10 @@ export default function ConversationScreen() {
           {item.replyTo && (
             <View className="border-l-2 border-[#3695FF] pl-2 mb-1">
               <Text className="text-xs text-[#515150] dark:text-[#d4d4d3]">
-                {item.replyTo.senderId === userId ? 'You' : otherUserInfo?.first_name}
+                {item.replyTo.senderId === userId ? t('you') : otherUserInfo?.first_name}
               </Text>
               <Text className="text-xs text-[#515150] dark:text-[#d4d4d3]" numberOfLines={1}>
-                {item.replyTo.type === 'text' ? item.replyTo.text : item.replyTo.type === 'image' ? 'Image' : 'File'}
+                {item.replyTo.type === 'text' ? item.replyTo.text : item.replyTo.type === 'image' ? t('image') : t('file')}
               </Text>
             </View>
           )}
@@ -427,10 +427,10 @@ export default function ConversationScreen() {
           {item.replyTo && (
             <View className="border-l-2 border-[#3695FF] pl-2 mb-1">
               <Text className="text-xs text-[#515150] dark:text-[#d4d4d3]">
-                {item.replyTo.senderId === userId ? 'You' : otherUserInfo?.first_name}
+                {item.replyTo.senderId === userId ? t('you') : otherUserInfo?.first_name}
               </Text>
               <Text className="text-xs text-[#515150] dark:text-[#d4d4d3]" numberOfLines={1}>
-                {item.replyTo.type === 'text' ? item.replyTo.text : item.replyTo.type === 'image' ? 'Image' : 'File'}
+                {item.replyTo.type === 'text' ? item.replyTo.text : item.replyTo.type === 'image' ? t('image') : t('file')}
               </Text>
             </View>
           )}
@@ -493,10 +493,10 @@ export default function ConversationScreen() {
           {item.replyTo && (
             <View className="border-l-2 border-[#3695FF] py-1 pl-2 pr-2 rounded-lg mb-2 bg-[#f2f2f2]/80 dark:bg-[#272626]/20">
               <Text className="font-inter-semibold text-xs text-[#515150] dark:text-[#d4d4d3]">
-                {item.replyTo.senderId === userId ? 'You' : otherUserInfo?.first_name}
+                {item.replyTo.senderId === userId ? t('you') : otherUserInfo?.first_name}
               </Text>
               <Text className="text-xs text-[#515150] dark:text-[#d4d4d3]" numberOfLines={1}>
-                {item.replyTo.type === 'text' ? item.replyTo.text : item.replyTo.type === 'image' ? 'Image' : 'File'}
+                {item.replyTo.type === 'text' ? item.replyTo.text : item.replyTo.type === 'image' ? t('image') : t('file')}
               </Text>
             </View>
           )}
@@ -611,10 +611,10 @@ export default function ConversationScreen() {
           <View className="flex-row items-center px-4 py-2 bg-[#e0e0e0] dark:bg-[#3d3d3d] rounded-t-xl ">
             <View className="flex-1 border-l-[3px] border-[#3695FF] pl-2">
               <Text className="font-inter-semibold text-xs text-[#515150] dark:text-[#d4d4d3]">
-                {replyTo.senderId === userId ? 'You' : otherUserInfo?.first_name}
+                {replyTo.senderId === userId ? t('you') : otherUserInfo?.first_name}
               </Text>
               <Text className="text-xs text-[#515150] dark:text-[#d4d4d3]" numberOfLines={1}>
-                {replyTo.type === 'text' ? replyTo.text : replyTo.type === 'image' ? 'Image' : 'File'}
+                {replyTo.type === 'text' ? replyTo.text : replyTo.type === 'image' ? t('image') : t('file')}
               </Text>
             </View>
             <TouchableOpacity onPress={() => setReplyTo(null)} className="p-1 ml-2">
@@ -719,11 +719,11 @@ export default function ConversationScreen() {
         <View className="py-4 px-7 space-y-4">
           <TouchableOpacity onPress={handleImagePick} className="py-2 flex-row justify-start items-center ">
             <ImageIcon height={24} width={24} color={iconColor} strokeWidth={2} />
-            <Text className=" ml-3 text-base font-inter-medium text-[#444343] dark:text-[#f2f2f2]">Choose image</Text>
+            <Text className=" ml-3 text-base font-inter-medium text-[#444343] dark:text-[#f2f2f2]">{t('choose_image')}</Text>
           </TouchableOpacity>
           <TouchableOpacity onPress={handleFilePick} className="py-1 flex-row justify-start items-center">
             <Folder height={24} width={24} color={iconColor} strokeWidth={2} />
-            <Text className="ml-3 text-base font-inter-medium text-[#444343] dark:text-[#f2f2f2]">Choose file</Text>
+            <Text className="ml-3 text-base font-inter-medium text-[#444343] dark:text-[#f2f2f2]">{t('choose_file')}</Text>
           </TouchableOpacity>
         </View>
       </RBSheet>


### PR DESCRIPTION
## Summary
- add missing translation keys for chat-related screens
- localize ConversationScreen strings
- localize ChatImageViewerScreen header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68667820b12c832b97f700a11307d373