### PR TITLE
Fix final price commission rule

### DIFF
--- a/Wisdom_expo/screens/booking/BookingDetailsScreen.js
+++ b/Wisdom_expo/screens/booking/BookingDetailsScreen.js
@@ -217,6 +217,11 @@ export default function BookingDetailsScreen() {
     return `${formatted.replace('.', ',')} ${symbol}`;
   };
 
+  const calculateCommission = (basePrice) => {
+    const commission = parseFloat((basePrice * 0.1).toFixed(1));
+    return commission < 1 ? 1 : commission;
+  };
+
   const getFormattedPrice = () => {
     const priceSource = service || booking;
     if (!priceSource) return null;
@@ -854,7 +859,7 @@ export default function BookingDetailsScreen() {
                           {'.'.repeat(80)}
                         </Text>
                         <Text className='font-inter-semibold text-[13px] text-[#979797] dark:text-[#979797]'>
-                          {formatCurrency(((parseFloat(priceSource.price) * (selectedDuration / 60)) * 1.1) - (parseFloat(priceSource.price) * (selectedDuration / 60)), priceSource.currency)}
+                          {formatCurrency(calculateCommission(parseFloat(priceSource.price) * (selectedDuration / 60)), priceSource.currency)}
                         </Text>
                       </View>
 
@@ -866,7 +871,7 @@ export default function BookingDetailsScreen() {
                           {'.'.repeat(80)}
                         </Text>
                         <Text className='font-inter-bold text-[13px] text-[#444343] dark:text-[#f2f2f2]'>
-                          {formatCurrency(((parseFloat(priceSource.price) * (selectedDuration / 60)) * 1.1), priceSource.currency)}
+                          {formatCurrency(parseFloat(priceSource.price) * (selectedDuration / 60) + calculateCommission(parseFloat(priceSource.price) * (selectedDuration / 60)), priceSource.currency)}
                         </Text>
                       </View>
 
@@ -900,7 +905,7 @@ export default function BookingDetailsScreen() {
                           {'.'.repeat(80)}
                         </Text>
                         <Text className='font-inter-semibold text-[13px] text-[#979797] dark:text-[#979797]'>
-                          {(parseFloat(priceSource.price) * 0.1).toFixed(1)} {currencySymbols[priceSource.currency]}
+                          {formatCurrency(calculateCommission(parseFloat(priceSource.price)), priceSource.currency)}
                         </Text>
                       </View>
 
@@ -912,7 +917,7 @@ export default function BookingDetailsScreen() {
                           {'.'.repeat(80)}
                         </Text>
                         <Text className='font-inter-bold text-[13px] text-[#444343] dark:text-[#f2f2f2]'>
-                          {formatCurrency(parseFloat(priceSource.price)+(parseFloat(priceSource.price) * 0.1), priceSource.currency)}
+                          {formatCurrency(parseFloat(priceSource.price) + calculateCommission(parseFloat(priceSource.price)), priceSource.currency)}
                         </Text>
                       </View>
 

--- a/Wisdom_expo/screens/home/BookingScreen.js
+++ b/Wisdom_expo/screens/home/BookingScreen.js
@@ -406,19 +406,26 @@ export default function BookingScreen() {
     return `${endDate} ${endTime}`;
   }
 
+  const calculateCommission = (basePrice) => {
+    const commission = parseFloat((basePrice * 0.1).toFixed(1));
+    return commission < 1 ? 1 : commission;
+  };
+
   const calculateFinalPrice = () => {
-    let final_price = null; 
+    let final_price = null;
 
     const durationInHours = duration / 60;
 
     if (serviceData.price_type === 'hour') {
-        final_price = ((parseFloat(serviceData.price) * durationInHours) * 1.1).toFixed(1);
+        const basePrice = parseFloat(serviceData.price) * durationInHours;
+        final_price = (basePrice + calculateCommission(basePrice)).toFixed(1);
     } else if (serviceData.price_type === 'fix') {
-        final_price = (parseFloat(serviceData.price) + (parseFloat(serviceData.price) * 0.1)).toFixed(1);
+        const basePrice = parseFloat(serviceData.price);
+        final_price = (basePrice + calculateCommission(basePrice)).toFixed(1);
     }
 
-    return final_price; 
-}
+    return final_price;
+  }
 
   const createBooking = async () => {
 
@@ -1002,7 +1009,7 @@ export default function BookingScreen() {
                         {'.'.repeat(80)}
                       </Text>
                       <Text className="font-inter-semibold text-[13px] text-[#979797] dark:text-[#979797]">
-                        {formatCurrency(((parseFloat(serviceData.price) * (duration / 60)) * 1.1) - (parseFloat(serviceData.price) * (duration / 60)), serviceData.currency)}
+                        {formatCurrency(calculateCommission(parseFloat(serviceData.price) * (duration / 60)), serviceData.currency)}
                       </Text>
                     </View>
 
@@ -1019,7 +1026,7 @@ export default function BookingScreen() {
                         {'.'.repeat(80)}
                       </Text>
                       <Text className="font-inter-bold text-[13px] text-[#444343] dark:text-[#f2f2f2]">
-                        {formatCurrency(((parseFloat(serviceData.price) * (duration / 60)) * 1.1), serviceData.currency)}
+                        {formatCurrency(parseFloat(serviceData.price) * (duration / 60) + calculateCommission(parseFloat(serviceData.price) * (duration / 60)), serviceData.currency)}
                       </Text>
                     </View>
 
@@ -1068,7 +1075,7 @@ export default function BookingScreen() {
                         {'.'.repeat(80)}
                       </Text>
                       <Text className="font-inter-semibold text-[13px] text-[#979797] dark:text-[#979797]">
-                        {formatCurrency(parseFloat(serviceData.price) * 0.1, serviceData.currency)}
+                        {formatCurrency(calculateCommission(parseFloat(serviceData.price)), serviceData.currency)}
                       </Text>
                     </View>
 
@@ -1085,7 +1092,7 @@ export default function BookingScreen() {
                         {'.'.repeat(80)}
                       </Text>
                       <Text className="font-inter-bold text-[13px] text-[#444343] dark:text-[#f2f2f2]">
-                        {formatCurrency(parseFloat(serviceData.price)+(parseFloat(serviceData.price) * 0.1), serviceData.currency)}
+                        {formatCurrency(parseFloat(serviceData.price) + calculateCommission(parseFloat(serviceData.price)), serviceData.currency)}
                       </Text>
                     </View>
 


### PR DESCRIPTION
## Summary
- enforce a 10% wisdom commission with a 1€ minimum
- show the updated commission and final price in booking screens

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6880d8e84110832bb9fa148a47e9a538