### PR TITLE
Fix payment method persistence on booking

### DIFF
--- a/Wisdom_expo/screens/home/BookingScreen.js
+++ b/Wisdom_expo/screens/home/BookingScreen.js
@@ -253,20 +253,15 @@ export default function BookingScreen() {
   };
 
   const loadPaymentMethod = async () => {
-    
     const PaymentMethodRaw = await getDataLocally('paymentMethod');
     if (PaymentMethodRaw) {
       const paymentMethodData = JSON.parse(PaymentMethodRaw);
       setPaymentMethod(paymentMethodData);
-      
-    }
-  };
-
-  const removePaymentMethod = async () => {
-    try {
-      await AsyncStorage.removeItem('paymentMethod');
-    } catch (error) {
-      console.error('Error al eliminar paymentMethod:', error);
+      try {
+        await AsyncStorage.removeItem('paymentMethod');
+      } catch (error) {
+        console.error('Error al eliminar paymentMethod:', error);
+      }
     }
   };
 
@@ -279,7 +274,6 @@ export default function BookingScreen() {
       loadDirections();
       loadSearchedDirection();
       loadPaymentMethod();
-      removePaymentMethod();
       
     }, [])
   );


### PR DESCRIPTION
## Summary
- ensure booking screen loads stored payment method and clears storage in one step
- remove redundant payment method clearing that caused repeated prompts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689513f3b674832bbab5853aa51ce7f0