### PR TITLE
Fix final payment navigation and payment method visibility

### DIFF
--- a/Wisdom_expo/languages/ar.json
+++ b/Wisdom_expo/languages/ar.json
@@ -160,7 +160,7 @@
     "cancellation_policy": "سياسة الإلغاء",
     "follow_the_rules": "اتبع القواعد",
     "contact_wisdom": "اتصل بـ Wisdom",
-    "continue_to_payment": "المتابعة إلى الدفع",
+    "continue_to_payment": "المتابعة مع الدفع",
     "add_payment_method": "إضافة طريقة دفع",
     "booking_successfully_completed": "تم الحجز بنجاح",
     "gallery": "معرض",

--- a/Wisdom_expo/languages/ca.json
+++ b/Wisdom_expo/languages/ca.json
@@ -160,7 +160,7 @@
     "cancellation_policy": "Política de cancel·lació",
     "follow_the_rules": "Seguiu les normes",
     "contact_wisdom": "Contacta amb Wisdom",
-    "continue_to_payment": "Continuar al pagament",
+    "continue_to_payment": "Continuar amb el pagament",
     "add_payment_method": "Afegir mètode de pagament",
     "booking_successfully_completed": "Reserva completada amb èxit",
     "gallery": "Galeria",

--- a/Wisdom_expo/languages/en.json
+++ b/Wisdom_expo/languages/en.json
@@ -160,7 +160,7 @@
     "cancellation_policy": "Cancellation Policy",
     "follow_the_rules": "Follow the rules",
     "contact_wisdom": "Contact Wisdom",
-    "continue_to_payment": "Continue to Payment",
+    "continue_to_payment": "Continue with payment",
     "add_payment_method": "Add Payment Method",
     "booking_successfully_completed": "Booking successfully completed",
     "gallery": "Gallery",

--- a/Wisdom_expo/languages/es.json
+++ b/Wisdom_expo/languages/es.json
@@ -160,7 +160,7 @@
     "cancellation_policy": "Política de cancelación",
     "follow_the_rules": "Sigue las normas",
     "contact_wisdom": "Contactar con Wisdom",
-    "continue_to_payment": "Continuar al pago",
+    "continue_to_payment": "Continuar con el pago",
     "add_payment_method": "Añadir método de pago",
     "booking_successfully_completed": "Reserva completada con éxito",
     "gallery": "Galería",

--- a/Wisdom_expo/languages/fr.json
+++ b/Wisdom_expo/languages/fr.json
@@ -160,7 +160,7 @@
     "cancellation_policy": "Politique d'annulation",
     "follow_the_rules": "Respecter les règles",
     "contact_wisdom": "Contacter Wisdom",
-    "continue_to_payment": "Continuer au paiement",
+    "continue_to_payment": "Continuer avec le paiement",
     "add_payment_method": "Ajouter un moyen de paiement",
     "booking_successfully_completed": "Réservation terminée avec succès",
     "gallery": "Galerie",

--- a/Wisdom_expo/screens/booking/BookingDetailsScreen.js
+++ b/Wisdom_expo/screens/booking/BookingDetailsScreen.js
@@ -994,52 +994,54 @@ export default function BookingDetailsScreen() {
         </View>
 
         {/* Payment Method */}
-        <View className='mt-8 flex-1 p-5 bg-[#fcfcfc] dark:bg-[#323131] rounded-2xl'>
-          <View className='w-full flex-row justify-between items-center '>
-            <Text className='font-inter-bold text-[16px] text-[#444343] dark:text-[#f2f2f2]'>Payment method</Text>
-            {editMode && paymentMethod && (
-              <TouchableOpacity onPress={() => navigation.navigate('PaymentMethod', { origin: 'BookingDetails', bookingId, role })}>
-                <Edit3 height={17} width={17} color={iconColor} strokeWidth={2.2} />
-              </TouchableOpacity>
-            )}
-          </View>
+        {role === 'client' && showServiceFinished && (
+          <View className='mt-8 flex-1 p-5 bg-[#fcfcfc] dark:bg-[#323131] rounded-2xl'>
+            <View className='w-full flex-row justify-between items-center '>
+              <Text className='font-inter-bold text-[16px] text-[#444343] dark:text-[#f2f2f2]'>Payment method</Text>
+              {editMode && paymentMethod && (
+                <TouchableOpacity onPress={() => navigation.navigate('PaymentMethod', { origin: 'BookingDetails', bookingId, role })}>
+                  <Edit3 height={17} width={17} color={iconColor} strokeWidth={2.2} />
+                </TouchableOpacity>
+              )}
+            </View>
 
-          <View className='mt-4 flex-1'>
-            {paymentMethod ? (
-              <View className='flex-1 my-3 justify-center items-center '>
-                <View className='px-7 pb-5 pt-[50px] bg-[#EEEEEE] dark:bg-[#111111] rounded-xl'>
-                  <Text>
-                    <Text className='font-inter-medium text-[16px] text-[#444343] dark:text-[#f2f2f2]'>••••   ••••   ••••   </Text>
-                    <Text className='font-inter-medium text-[13px] text-[#444343] dark:text-[#f2f2f2]'>{paymentMethod.last4}</Text>
-                  </Text>
+            <View className='mt-4 flex-1'>
+              {paymentMethod ? (
+                <View className='flex-1 my-3 justify-center items-center '>
+                  <View className='px-7 pb-5 pt-[50px] bg-[#EEEEEE] dark:bg-[#111111] rounded-xl'>
+                    <Text>
+                      <Text className='font-inter-medium text-[16px] text-[#444343] dark:text-[#f2f2f2]'>••••   ••••   ••••   </Text>
+                      <Text className='font-inter-medium text-[13px] text-[#444343] dark:text-[#f2f2f2]'>{paymentMethod.last4}</Text>
+                    </Text>
 
-                  <View className='mt-6 flex-row justify-between items-center'>
-                    <View className='flex-row items-center'>
-                      <View className='justify-center items-center'>
-                        <Text className='font-inter-medium text-[12px] text-[#444343] dark:text-[#f2f2f2]'>{paymentMethod.expiryMonth}/{paymentMethod.expiryYear}</Text>
+                    <View className='mt-6 flex-row justify-between items-center'>
+                      <View className='flex-row items-center'>
+                        <View className='justify-center items-center'>
+                          <Text className='font-inter-medium text-[12px] text-[#444343] dark:text-[#f2f2f2]'>{paymentMethod.expiryMonth}/{paymentMethod.expiryYear}</Text>
+                        </View>
                       </View>
-                    </View>
 
-                    <View className='h-5 w-8 bg-[#fcfcfc] dark:bg-[#323131] rounded-md'/>
+                      <View className='h-5 w-8 bg-[#fcfcfc] dark:bg-[#323131] rounded-md'/>
+                    </View>
                   </View>
                 </View>
-              </View>
-            ) : (
-              <View className='mt-1 flex-1 justify-center items-center'>
-                <CreditCard height={55} width={55} strokeWidth={1.3} color={colorScheme === 'dark' ? '#474646' : '#d4d3d3'} />
-                <View className='flex-row justify-center items-center px-6'>
-                <TouchableOpacity onPress={() => navigation.navigate('PaymentMethod', { origin: 'BookingDetails', bookingId, role }) } style={{ opacity: 1 }} className='bg-[#706f6e] my-2 mt-3 dark:bg-[#b6b5b5] w-full py-[14px] rounded-full items-center justify-center'>
-                    <Text>
-                      <Text className='font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]'>
-                        {t('add_credit_card')}
+              ) : (
+                <View className='mt-1 flex-1 justify-center items-center'>
+                  <CreditCard height={55} width={55} strokeWidth={1.3} color={colorScheme === 'dark' ? '#474646' : '#d4d3d3'} />
+                  <View className='flex-row justify-center items-center px-6'>
+                  <TouchableOpacity onPress={() => navigation.navigate('PaymentMethod', { origin: 'BookingDetails', bookingId, role }) } style={{ opacity: 1 }} className='bg-[#706f6e] my-2 mt-3 dark:bg-[#b6b5b5] w-full py-[14px] rounded-full items-center justify-center'>
+                      <Text>
+                        <Text className='font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]'>
+                          {t('add_credit_card')}
+                        </Text>
                       </Text>
-                    </Text>
-                  </TouchableOpacity>
+                    </TouchableOpacity>
+                  </View>
                 </View>
-              </View>
-            )}
+              )}
+            </View>
           </View>
-        </View>
+        )}
 
         {/* Description */}
         <View className='mt-4 flex-1 p-5 bg-[#fcfcfc] dark:bg-[#323131] rounded-2xl'>

--- a/Wisdom_expo/screens/home/BookingScreen.js
+++ b/Wisdom_expo/screens/home/BookingScreen.js
@@ -1367,8 +1367,6 @@ export default function BookingScreen() {
 
         <TouchableOpacity
           onPress={handleBook}
-          disabled={!paymentMethod}
-          style={{ opacity: paymentMethod ? 1 : 0.5 }}
           className="bg-[#323131] mt-3 dark:bg-[#fcfcfc] w-full h-[55px] rounded-full items-center justify-center"
         >
           <Text className="font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]">

--- a/Wisdom_expo/screens/home/PaymentMethodScreen.js
+++ b/Wisdom_expo/screens/home/PaymentMethodScreen.js
@@ -83,6 +83,13 @@ export default function PaymentMethodScreen() {
         await api.post(`/api/bookings/${bookingId}/final-payment-transfer`, {
           payment_method_id: paymentMethod.id,
         });
+        setProcessing(false);
+        if (onSuccess) {
+          navigation.navigate(onSuccess, { bookingId });
+        } else {
+          handleBack();
+        }
+        return;
       } else {
         const { paymentMethod, error } = await createPaymentMethod({
           paymentMethodType: 'Card',
@@ -103,8 +110,6 @@ export default function PaymentMethodScreen() {
         handleBack();
         return;
       }
-
-      handleBack();
     } catch (e) {
       console.log('handleDone error', e);
       setProcessing(false);


### PR DESCRIPTION
## Summary
- Redirect to payment confirmation after completing final payment from Booking Details
- Show payment method section only to clients when the service is completed
- Allow booking button to open add card flow and improve "Continue with payment" translations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_689712f74f40832b923c5e2a7c467d39