### PR TITLE
feat: split DNI flow into birthdate and ID steps

### DIFF
--- a/Wisdom_expo/navigation/navigation.js
+++ b/Wisdom_expo/navigation/navigation.js
@@ -93,6 +93,7 @@ import ExpertPlansScreen from '../screens/settings/ExpertPlansScreen';
 import FAQScreen from '../screens/settings/FAQScreen';
 import EditProfileScreen from '../screens/settings/EditProfileScreen';
 import CollectionMethod1Screen from '../screens/settings/CollectionMethod1Screen';
+import CollectionMethodBirthScreen from '../screens/settings/CollectionMethodBirthScreen';
 import CollectionMethodDniScreen from '../screens/settings/CollectionMethodDniScreen';
 import CollectionMethodPhoneScreen from '../screens/settings/CollectionMethodPhoneScreen';
 import CollectionMethod2Screen from '../screens/settings/CollectionMethod2Screen';
@@ -199,6 +200,7 @@ export default function Navigation() {
         <Stack.Screen name="FAQ" component={FAQScreen} />
         <Stack.Screen name="EditProfile" component={EditProfileScreen} />
         <Stack.Screen name="CollectionMethod1" component={CollectionMethod1Screen} options={{ animation: 'none', gestureEnabled: false }}/>
+        <Stack.Screen name="CollectionMethodBirth" component={CollectionMethodBirthScreen} options={{ animation: 'none', gestureEnabled: false }}/>
         <Stack.Screen name="CollectionMethodDni" component={CollectionMethodDniScreen} options={{ animation: 'none', gestureEnabled: false }}/>
         <Stack.Screen name="CollectionMethodPhone" component={CollectionMethodPhoneScreen} options={{ animation: 'none', gestureEnabled: false }}/>
         <Stack.Screen name="CollectionMethod2" component={CollectionMethod2Screen} options={{ animation: 'none', gestureEnabled: false }}/>
@@ -580,6 +582,7 @@ function SettingsStackNavigator() {
       <Stack.Screen name="Directions" component={DirectionsScreen} />
       <Stack.Screen name="AddDirection" component={SearchDirectionScreen} />
       <Stack.Screen name="CollectionMethod1" component={CollectionMethod1Screen} options={{ animation: 'none', gestureEnabled: false }}/>
+      <Stack.Screen name="CollectionMethodBirth" component={CollectionMethodBirthScreen} options={{ animation: 'none', gestureEnabled: false }}/>
       <Stack.Screen name="CollectionMethodDni" component={CollectionMethodDniScreen} options={{ animation: 'none', gestureEnabled: false }}/>
       <Stack.Screen name="CollectionMethodPhone" component={CollectionMethodPhoneScreen} options={{ animation: 'none', gestureEnabled: false }}/>
       <Stack.Screen name="CollectionMethod2" component={CollectionMethod2Screen} options={{ animation: 'none', gestureEnabled: false }}/>

--- a/Wisdom_expo/screens/settings/CollectionMethod1Screen.js
+++ b/Wisdom_expo/screens/settings/CollectionMethod1Screen.js
@@ -52,7 +52,7 @@ export default function CollectionMethod1Screen() {
               </TouchableOpacity>
               <TouchableOpacity
               disabled={fullName.length < 1}
-              onPress={() => navigation.navigate('CollectionMethodDni', { fullName })}
+              onPress={() => navigation.navigate('CollectionMethodBirth', { fullName })}
               style={{opacity: fullName.length < 1 ? 0.5 : 1.0}}
               className="ml-[10px] bg-[#323131] dark:bg-[#fcfcfc] w-3/4 h-[55px] rounded-full items-center justify-center" >
                   <Text className="font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]">{t('continue')}</Text>

--- a/Wisdom_expo/screens/settings/CollectionMethodBirthScreen.js
+++ b/Wisdom_expo/screens/settings/CollectionMethodBirthScreen.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { useColorScheme } from 'nativewind';
+import '../../languages/i18n';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import DatePicker from 'react-native-date-picker';
+import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+
+export default function CollectionMethodBirthScreen() {
+  const { colorScheme } = useColorScheme();
+  const { t } = useTranslation();
+  const navigation = useNavigation();
+  const route = useRoute();
+  const { fullName } = route.params;
+  const iconColor = colorScheme === 'dark' ? '#706F6E' : '#B6B5B5';
+  const [date, setDate] = useState(new Date());
+
+  return (
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+      <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
+      <View className="flex-1 px-6 pt-5 pb-6">
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <View className="flex-row justify-start">
+            <ChevronLeftIcon size={25} color={iconColor} strokeWidth={2} />
+          </View>
+        </TouchableOpacity>
+        <View className="justify-center items-center">
+          <Text className="mt-[55px] font-inter-bold text-[28px] text-center text-[#444343] dark:text-[#f2f2f2]">{t('date_of_birth')}</Text>
+        </View>
+        <View className="flex-1 justify-center items-center">
+          <DatePicker
+            mode="date"
+            date={date}
+            onDateChange={setDate}
+            textColor={colorScheme === 'dark' ? '#f2f2f2' : '#444343'}
+            androidVariant="iosClone"
+          />
+        </View>
+        <View className="flex-row justify-center items-center">
+          <TouchableOpacity
+            onPress={() => navigation.goBack()}
+            className="bg-[#e0e0e0] dark:bg-[#3d3d3d] w-1/4 h-[55px] rounded-full items-center justify-center" >
+            <Text className="font-inter-medium text-[15px] text-[#323131] dark:text-[#fcfcfc]">{t('back')}</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('CollectionMethodDni', { fullName, dateOfBirth: date.toISOString().split('T')[0] })}
+            className="ml-[10px] bg-[#323131] dark:bg-[#fcfcfc] w-3/4 h-[55px] rounded-full items-center justify-center" >
+            <Text className="font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]">{t('continue')}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+

--- a/Wisdom_expo/screens/settings/CollectionMethodDniScreen.js
+++ b/Wisdom_expo/screens/settings/CollectionMethodDniScreen.js
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
-import DateTimePicker from '@react-native-community/datetimepicker';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
 import * as ImagePicker from 'expo-image-picker';
 
@@ -13,23 +12,14 @@ export default function CollectionMethodDniScreen() {
   const { t } = useTranslation();
   const navigation = useNavigation();
   const route = useRoute();
-  const { fullName } = route.params;
+  const { fullName, dateOfBirth } = route.params;
   const iconColor = colorScheme === 'dark' ? '#706F6E' : '#B6B5B5';
   const placeholderTextColorChange = colorScheme === 'dark' ? '#979797' : '#979797';
   const cursorColorChange = colorScheme === 'dark' ? '#f2f2f2' : '#444343';
 
   const [dni, setDni] = useState('');
-  const [date, setDate] = useState(new Date());
-  const [openDate, setOpenDate] = useState(false);
   const [frontImage, setFrontImage] = useState(null);
   const [backImage, setBackImage] = useState(null);
-
-  const handleDateChange = (event, selectedDate) => {
-    if (selectedDate) {
-      setDate(selectedDate);
-    }
-    setOpenDate(false);
-  };
 
   const takePhoto = async (side) => {
     const permission = await ImagePicker.requestCameraPermissionsAsync();
@@ -102,19 +92,6 @@ export default function CollectionMethodDniScreen() {
                   className="h-[50px] w-full flex-1 font-inter-medium text-[18px] text-[#515150] dark:text-[#d4d4d3]"
                   />
                 </View>
-                <TouchableOpacity onPress={() => setOpenDate(true)} className="w-full h-10 mb-6 p-2 border-b-[1px] border-[#444343] dark:border-[#f2f2f2] justify-center">
-                  <Text className="font-inter-medium text-[18px] text-[#515150] dark:text-[#d4d4d3]">
-                    {t('date_of_birth')}: {date.toISOString().split('T')[0]}
-                  </Text>
-                </TouchableOpacity>
-                {openDate && (
-                  <DateTimePicker
-                    value={date}
-                    mode="date"
-                    display="default"
-                    onChange={handleDateChange}
-                  />
-                )}
                 <View className="w-full flex-row justify-between mt-6">
                   <TouchableOpacity
                     onPress={() => handleImage('front')}
@@ -146,7 +123,7 @@ export default function CollectionMethodDniScreen() {
                 </TouchableOpacity>
                 <TouchableOpacity
                 disabled={!(dni && frontImage && backImage)}
-                onPress={() => navigation.navigate('CollectionMethodPhone', { fullName, dni, dateOfBirth: date.toISOString().split('T')[0], frontImage, backImage })}
+                onPress={() => navigation.navigate('CollectionMethodPhone', { fullName, dni, dateOfBirth, frontImage, backImage })}
                 style={{opacity: dni && frontImage && backImage ? 1.0 : 0.5}}
                 className="ml-[10px] bg-[#323131] dark:bg-[#fcfcfc] w-3/4 h-[55px] rounded-full items-center justify-center" >
                     <Text className="font-inter-semibold text-[15px] text-[#fcfcfc] dark:text-[#323131]">{t('continue')}</Text>


### PR DESCRIPTION
## Summary
- add dedicated birth date screen with spinner-style picker
- move DNI input and photo capture to second screen
- wire new flow into navigation

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68974d7d38b4832baa5b6bcbf0a89232