### PR TITLE
Align screen names with new create service and collection method flow

### DIFF
--- a/Wisdom_expo/navigation/navigation.js
+++ b/Wisdom_expo/navigation/navigation.js
@@ -49,21 +49,21 @@ import ConversationScreen from '../screens/chat/ConversationScreen';
 import ChatImageViewerScreen from '../screens/chat/ChatImageViewerScreen';
 import PreferencesScreen from '../screens/settings/PreferencesScreen';
 import LanguageScreen from '../screens/settings/LanguageScreen';
-import CreateService1Screen from '../screens/professional/create_service/CreateServiceStartScreen';
-import CreateService2Screen from '../screens/professional/create_service/CreateServiceTitleScreen';
-import CreateService3Screen from '../screens/professional/create_service/CreateServiceClassificationScreen';
-import CreateService4Screen from '../screens/professional/create_service/CreateServiceDescriptionScreen';
-import CreateService5Screen from '../screens/professional/create_service/CreateServiceDetailsScreen';
-import CreateService6Screen from '../screens/professional/create_service/CreateServiceLocationScreen';
-import CreateService7Screen from '../screens/professional/create_service/CreateServiceExperiencesScreen';
-import CreateService8Screen from '../screens/professional/create_service/CreateServiceImagesScreen';
-import CreateService9_0Screen from '../screens/professional/create_service/CreateServicePriceTypeScreen';
-import CreateService9Screen from '../screens/professional/create_service/CreateServicePriceScreen';
-import CreateService11_0Screen from '../screens/professional/create_service/CreateServiceAskScreen';
-import CreateService10Screen from '../screens/professional/create_service/CreateServiceDiscountsScreen';
-import CreateService11Screen from '../screens/professional/create_service/CreateServiceConsultScreen';
-import CreateService12Screen from '../screens/professional/create_service/CreateServiceTermsScreen';
-import CreateService13Screen from '../screens/professional/create_service/CreateServiceReviewScreen';
+import CreateServiceStartScreen from '../screens/professional/create_service/CreateServiceStartScreen';
+import CreateServiceTitleScreen from '../screens/professional/create_service/CreateServiceTitleScreen';
+import CreateServiceClassificationScreen from '../screens/professional/create_service/CreateServiceClassificationScreen';
+import CreateServiceDescriptionScreen from '../screens/professional/create_service/CreateServiceDescriptionScreen';
+import CreateServiceDetailsScreen from '../screens/professional/create_service/CreateServiceDetailsScreen';
+import CreateServiceLocationScreen from '../screens/professional/create_service/CreateServiceLocationScreen';
+import CreateServiceExperiencesScreen from '../screens/professional/create_service/CreateServiceExperiencesScreen';
+import CreateServiceImagesScreen from '../screens/professional/create_service/CreateServiceImagesScreen';
+import CreateServicePriceTypeScreen from '../screens/professional/create_service/CreateServicePriceTypeScreen';
+import CreateServicePriceScreen from '../screens/professional/create_service/CreateServicePriceScreen';
+import CreateServiceAskScreen from '../screens/professional/create_service/CreateServiceAskScreen';
+import CreateServiceDiscountsScreen from '../screens/professional/create_service/CreateServiceDiscountsScreen';
+import CreateServiceConsultScreen from '../screens/professional/create_service/CreateServiceConsultScreen';
+import CreateServiceTermsScreen from '../screens/professional/create_service/CreateServiceTermsScreen';
+import CreateServiceReviewScreen from '../screens/professional/create_service/CreateServiceReviewScreen';
 import SearchDirectionScreen from '../screens/home/SearchDirectionScreen';
 import BookingScreen from '../screens/booking/BookingScreen';
 import ConfirmPaymentScreen from '../screens/home/ConfirmPaymentScreen';
@@ -92,14 +92,14 @@ import WalletProScreen from '../screens/professional/WalletProScreen';
 import ExpertPlansScreen from '../screens/settings/ExpertPlansScreen';
 import FAQScreen from '../screens/settings/FAQScreen';
 import EditProfileScreen from '../screens/settings/EditProfileScreen';
-import CollectionMethod1Screen from '../screens/professional/collection_method/CollectionMethodNameScreen';
+import CollectionMethodNameScreen from '../screens/professional/collection_method/CollectionMethodNameScreen';
 import CollectionMethodBirthScreen from '../screens/professional/collection_method/CollectionMethodBirthScreen';
 import CollectionMethodDniScreen from '../screens/professional/collection_method/CollectionMethodDniScreen';
 import CollectionMethodPhoneScreen from '../screens/professional/collection_method/CollectionMethodPhoneScreen';
 import DniCameraScreen from '../screens/professional/collection_method/DniCameraScreen';
-import CollectionMethod2Screen from '../screens/professional/collection_method/CollectionMethodIbanScreen';
-import CollectionMethod3Screen from '../screens/professional/collection_method/CollectionMethodDirectionScreen';
-import CollectionMethod4Screen from '../screens/professional/collection_method/CollectionMethodConfirmScreen';
+import CollectionMethodIbanScreen from '../screens/professional/collection_method/CollectionMethodIbanScreen';
+import CollectionMethodDirectionScreen from '../screens/professional/collection_method/CollectionMethodDirectionScreen';
+import CollectionMethodConfirmScreen from '../screens/professional/collection_method/CollectionMethodConfirmScreen';
 
 
 
@@ -155,21 +155,21 @@ export default function Navigation() {
         <Stack.Screen name="Language" component={LanguageScreen} />
         <Stack.Screen name="List" component={ListScreen} />
         <Stack.Screen name="CreateServiceStack" component={CreateServiceStackNavigator} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceStart" component={CreateService1Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceTitle" component={CreateService2Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceClassification" component={CreateService3Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceDescription" component={CreateService4Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceDetails" component={CreateService5Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceLocation" component={CreateService6Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceExperiences" component={CreateService7Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceImages" component={CreateService8Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServicePrice" component={CreateService9Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServicePriceType" component={CreateService9_0Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceDiscounts" component={CreateService10Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceAsk" component={CreateService11_0Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceConsult" component={CreateService11Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceTerms" component={CreateService12Screen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CreateServiceReview" component={CreateService13Screen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceStart" component={CreateServiceStartScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceTitle" component={CreateServiceTitleScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceClassification" component={CreateServiceClassificationScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceDescription" component={CreateServiceDescriptionScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceDetails" component={CreateServiceDetailsScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceLocation" component={CreateServiceLocationScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceExperiences" component={CreateServiceExperiencesScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceImages" component={CreateServiceImagesScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServicePrice" component={CreateServicePriceScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServicePriceType" component={CreateServicePriceTypeScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceDiscounts" component={CreateServiceDiscountsScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceAsk" component={CreateServiceAskScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceConsult" component={CreateServiceConsultScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceTerms" component={CreateServiceTermsScreen} options={{ animation: 'none', gestureEnabled: false }} />
+        <Stack.Screen name="CreateServiceReview" component={CreateServiceReviewScreen} options={{ animation: 'none', gestureEnabled: false }} />
         <Stack.Screen name="Booking" component={BookingScreen} />
         <Stack.Screen name="ConfirmPayment" component={ConfirmPaymentScreen} options={{ animation: 'none', gestureEnabled: false }} />
         <Stack.Screen name="PaymentMethod" component={PaymentMethodScreen} />
@@ -200,14 +200,14 @@ export default function Navigation() {
         <Stack.Screen name="ExpertPlans" component={ExpertPlansScreen} options={{ animation: 'none', gestureEnabled: false }} />
         <Stack.Screen name="FAQ" component={FAQScreen} />
         <Stack.Screen name="EditProfile" component={EditProfileScreen} />
-        <Stack.Screen name="CollectionMethodName" component={CollectionMethod1Screen} options={{ animation: 'none', gestureEnabled: false }}/>
+        <Stack.Screen name="CollectionMethodName" component={CollectionMethodNameScreen} options={{ animation: 'none', gestureEnabled: false }}/>
         <Stack.Screen name="CollectionMethodBirth" component={CollectionMethodBirthScreen} options={{ animation: 'none', gestureEnabled: false }}/>
         <Stack.Screen name="CollectionMethodDni" component={CollectionMethodDniScreen} options={{ animation: 'none', gestureEnabled: false }}/>
         <Stack.Screen name="CollectionMethodPhone" component={CollectionMethodPhoneScreen} options={{ animation: 'none', gestureEnabled: false }}/>
         <Stack.Screen name="DniCamera" component={DniCameraScreen} options={{ animation: 'none', gestureEnabled: false }} />
-        <Stack.Screen name="CollectionMethodIban" component={CollectionMethod2Screen} options={{ animation: 'none', gestureEnabled: false }}/>
-        <Stack.Screen name="CollectionMethodDirection" component={CollectionMethod3Screen} options={{ animation: 'none', gestureEnabled: false }}/>
-        <Stack.Screen name="CollectionMethodConfirm" component={CollectionMethod4Screen} options={{ animation: 'none', gestureEnabled: false }}/>
+        <Stack.Screen name="CollectionMethodIban" component={CollectionMethodIbanScreen} options={{ animation: 'none', gestureEnabled: false }}/>
+        <Stack.Screen name="CollectionMethodDirection" component={CollectionMethodDirectionScreen} options={{ animation: 'none', gestureEnabled: false }}/>
+        <Stack.Screen name="CollectionMethodConfirm" component={CollectionMethodConfirmScreen} options={{ animation: 'none', gestureEnabled: false }}/>
       </Stack.Navigator>
     </NavigationContainer>
   );
@@ -583,13 +583,13 @@ function SettingsStackNavigator() {
       <Stack.Screen name="EditProfile" component={EditProfileScreen} />
       <Stack.Screen name="Directions" component={DirectionsScreen} />
       <Stack.Screen name="AddDirection" component={SearchDirectionScreen} />
-      <Stack.Screen name="CollectionMethodName" component={CollectionMethod1Screen} options={{ animation: 'none', gestureEnabled: false }}/>
+      <Stack.Screen name="CollectionMethodName" component={CollectionMethodNameScreen} options={{ animation: 'none', gestureEnabled: false }}/>
       <Stack.Screen name="CollectionMethodBirth" component={CollectionMethodBirthScreen} options={{ animation: 'none', gestureEnabled: false }}/>
       <Stack.Screen name="CollectionMethodDni" component={CollectionMethodDniScreen} options={{ animation: 'none', gestureEnabled: false }}/>
       <Stack.Screen name="CollectionMethodPhone" component={CollectionMethodPhoneScreen} options={{ animation: 'none', gestureEnabled: false }}/>
-      <Stack.Screen name="CollectionMethodIban" component={CollectionMethod2Screen} options={{ animation: 'none', gestureEnabled: false }}/>
-      <Stack.Screen name="CollectionMethodDirection" component={CollectionMethod3Screen} options={{ animation: 'none', gestureEnabled: false }}/>
-      <Stack.Screen name="CollectionMethodConfirm" component={CollectionMethod4Screen} options={{ animation: 'none', gestureEnabled: false }}/>
+      <Stack.Screen name="CollectionMethodIban" component={CollectionMethodIbanScreen} options={{ animation: 'none', gestureEnabled: false }}/>
+      <Stack.Screen name="CollectionMethodDirection" component={CollectionMethodDirectionScreen} options={{ animation: 'none', gestureEnabled: false }}/>
+      <Stack.Screen name="CollectionMethodConfirm" component={CollectionMethodConfirmScreen} options={{ animation: 'none', gestureEnabled: false }}/>
       <Stack.Screen name="DniCamera" component={DniCameraScreen} options={{ animation: 'none', gestureEnabled: false }} />
     </Stack.Navigator>
   );
@@ -598,21 +598,21 @@ function SettingsStackNavigator() {
 function CreateServiceStackNavigator() {
   return (
     <Stack.Navigator screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="CreateServiceStart" component={CreateService1Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceTitle" component={CreateService2Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceClassification" component={CreateService3Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceDescription" component={CreateService4Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceDetails" component={CreateService5Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceLocation" component={CreateService6Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceExperiences" component={CreateService7Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceImages" component={CreateService8Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServicePrice" component={CreateService9Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServicePriceType" component={CreateService9_0Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceDiscounts" component={CreateService10Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceAsk" component={CreateService11_0Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceConsult" component={CreateService11Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceTerms" component={CreateService12Screen} options={{ animation: 'none', gestureEnabled: false }} />
-      <Stack.Screen name="CreateServiceReview" component={CreateService13Screen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceStart" component={CreateServiceStartScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceTitle" component={CreateServiceTitleScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceClassification" component={CreateServiceClassificationScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceDescription" component={CreateServiceDescriptionScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceDetails" component={CreateServiceDetailsScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceLocation" component={CreateServiceLocationScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceExperiences" component={CreateServiceExperiencesScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceImages" component={CreateServiceImagesScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServicePrice" component={CreateServicePriceScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServicePriceType" component={CreateServicePriceTypeScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceDiscounts" component={CreateServiceDiscountsScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceAsk" component={CreateServiceAskScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceConsult" component={CreateServiceConsultScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceTerms" component={CreateServiceTermsScreen} options={{ animation: 'none', gestureEnabled: false }} />
+      <Stack.Screen name="CreateServiceReview" component={CreateServiceReviewScreen} options={{ animation: 'none', gestureEnabled: false }} />
       <Stack.Screen name="SearchDirectionCreateService" component={SearchDirectionScreen} />
     </Stack.Navigator>
   );

--- a/Wisdom_expo/screens/professional/CalendarProScreen.js
+++ b/Wisdom_expo/screens/professional/CalendarProScreen.js
@@ -167,7 +167,7 @@ export default function CalendarProScreen() {
             <Text className=" font-inter-bold text-[28px] text-[#444343] dark:text-[#f2f2f2]">
               {t('calendar')}
             </Text>
-            {/* <TouchableOpacity onPress={() => navigation.navigate('CreateService1')} className="p-[8px] bg-[#fcfcfc] dark:bg-[#323131] rounded-full">
+            {/* <TouchableOpacity onPress={() => navigation.navigate('CreateServiceStart')} className="p-[8px] bg-[#fcfcfc] dark:bg-[#323131] rounded-full">
               <Plus height={23} width={23} color={iconColor} strokeWidth={1.7}/>
             </TouchableOpacity> */}
         </View>

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodConfirmScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodConfirmScreen.js
@@ -8,7 +8,7 @@ import { ChevronLeftIcon } from 'react-native-heroicons/outline';
 import api from '../../../utils/api.js';
 import { getDataLocally, storeDataLocally } from '../../../utils/asyncStorage';
 
-export default function CollectionMethod4Screen() {
+export default function CollectionMethodConfirmScreen() {
   const { colorScheme } = useColorScheme();
   const { t } = useTranslation();
   const navigation = useNavigation();

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodDirectionScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodDirectionScreen.js
@@ -8,7 +8,7 @@ import { ChevronLeftIcon, ChevronDownIcon, ChevronUpIcon } from 'react-native-he
 import Triangle from '../../../assets/triangle';
 import { formatE164IfMissing } from '../../../utils/phone';
 
-export default function CollectionMethod3Screen() {
+export default function CollectionMethodDirectionScreen() {
   const { colorScheme } = useColorScheme();
   const { t } = useTranslation();
   const navigation = useNavigation();

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodIbanScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodIbanScreen.js
@@ -6,7 +6,7 @@ import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { XMarkIcon, ChevronLeftIcon } from 'react-native-heroicons/outline';
 
-export default function CollectionMethod2Screen() {
+export default function CollectionMethodIbanScreen() {
   const { colorScheme } = useColorScheme();
   const { t } = useTranslation();
   const navigation = useNavigation();

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodNameScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodNameScreen.js
@@ -6,7 +6,7 @@ import '../../../languages/i18n';
 import { useNavigation } from '@react-navigation/native';
 import { XMarkIcon } from 'react-native-heroicons/outline';
 
-export default function CollectionMethod1Screen() {
+export default function CollectionMethodNameScreen() {
   const { colorScheme } = useColorScheme();
   const { t } = useTranslation();
   const navigation = useNavigation();

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceAskScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceAskScreen.js
@@ -8,7 +8,7 @@ import {XMarkIcon, ChevronDownIcon, ChevronUpIcon} from 'react-native-heroicons/
 import { Edit3 } from 'react-native-feather';
 
 
-export default function CreateService11_0Screen() {
+export default function CreateServiceAskScreen() {
 
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceClassificationScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceClassificationScreen.js
@@ -21,7 +21,7 @@ import Triangle from '../../../assets/triangle';
 import api from '../../../utils/api.js';
 
 
-export default function CreateService3Screen() {
+export default function CreateServiceClassificationScreen() {
   const { colorScheme } = useColorScheme();
   const { t } = useTranslation();
   const navigation = useNavigation();

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceConsultScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceConsultScreen.js
@@ -8,7 +8,7 @@ import {XMarkIcon, ChevronDownIcon, ChevronUpIcon} from 'react-native-heroicons/
 import { Edit3 } from 'react-native-feather';
 
 
-export default function CreateService11Screen() {
+export default function CreateServiceConsultScreen() {
 
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDescriptionScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDescriptionScreen.js
@@ -6,7 +6,7 @@ import { useColorScheme } from 'nativewind';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { XMarkIcon } from 'react-native-heroicons/outline';
 
-export default function CreateService4Screen() {
+export default function CreateServiceDescriptionScreen() {
   const { colorScheme } = useColorScheme();
   const { t, i18n } = useTranslation();
   const iconColor = colorScheme === 'dark' ? '#706F6E' : '#B6B5B5';

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDetailsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDetailsScreen.js
@@ -9,7 +9,7 @@ import { Check } from "react-native-feather";
 
 
 
-export default function CreateService5Screen() {
+export default function CreateServiceDetailsScreen() {
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();
   const iconColor = colorScheme === 'dark' ? '#b6b5b5' : '#706F6E';

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDiscountsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDiscountsScreen.js
@@ -7,7 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon, ChevronDownIcon, ChevronUpIcon} from 'react-native-heroicons/outline';
 
 
-export default function CreateService10Screen() {
+export default function CreateServiceDiscountsScreen() {
 
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceExperiencesScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceExperiencesScreen.js
@@ -8,7 +8,7 @@ import { XMarkIcon } from 'react-native-heroicons/outline';
 import DateTimePicker from '@react-native-community/datetimepicker';
 
 
-export default function CreateService7Screen() {
+export default function CreateServiceExperiencesScreen() {
   const { colorScheme } = useColorScheme();
   const { t, i18n } = useTranslation();
   const iconColor = colorScheme === 'dark' ? '#706F6E' : '#B6B5B5';

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceImagesScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceImagesScreen.js
@@ -85,7 +85,7 @@ const patternImages = (images, colorScheme, onRemoveImage) => {
   return pattern;
 };
 
-export default function CreateService8Screen() {
+export default function CreateServiceImagesScreen() {
   const { colorScheme } = useColorScheme();
   const { t, i18n } = useTranslation();
   const iconColor = colorScheme === 'dark' ? '#706F6E' : '#B6B5B5';

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceLocationScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceLocationScreen.js
@@ -17,7 +17,7 @@ import SliderThumbLight from '../../assets/SliderThumbLight.png';
 
 
 
-export default function CreateService6Screen() {
+export default function CreateServiceLocationScreen() {
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();
   const iconColor = colorScheme === 'dark' ? '#706F6E' : '#B6B5B5';

--- a/Wisdom_expo/screens/professional/create_service/CreateServicePriceScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServicePriceScreen.js
@@ -7,7 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { XMarkIcon, ChevronDownIcon, ChevronUpIcon } from 'react-native-heroicons/outline';
 import { Edit3 } from 'react-native-feather';
 
-export default function CreateService9Screen() {
+export default function CreateServicePriceScreen() {
 
   const { colorScheme, toggleColorScheme } = useColorScheme();
   const { t, i18n } = useTranslation();

--- a/Wisdom_expo/screens/professional/create_service/CreateServicePriceTypeScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServicePriceTypeScreen.js
@@ -7,7 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon, ChevronDownIcon, ChevronUpIcon} from 'react-native-heroicons/outline';
 
 
-export default function CreateService9_0Screen() {
+export default function CreateServicePriceTypeScreen() {
 
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
@@ -15,7 +15,7 @@ import axios from 'axios';
 
 
 
-export default function CreateService13Screen() {
+export default function CreateServiceReviewScreen() {
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();
   const navigation = useNavigation();

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceStartScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceStartScreen.js
@@ -10,7 +10,7 @@ import {XMarkIcon} from 'react-native-heroicons/outline';
 
 
 
-export default function CreateService1Screen() {
+export default function CreateServiceStartScreen() {
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();
   const iconColor = colorScheme === 'dark' ? '#706F6E' : '#B6B5B5';

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceTermsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceTermsScreen.js
@@ -8,7 +8,7 @@ import {XMarkIcon, ChevronLeftIcon} from 'react-native-heroicons/outline';
 
 
 
-export default function CreateService12Screen() {
+export default function CreateServiceTermsScreen() {
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();
   const navigation = useNavigation();

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceTitleScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceTitleScreen.js
@@ -8,7 +8,7 @@ import {XMarkIcon} from 'react-native-heroicons/outline';
 
 
 
-export default function CreateService2Screen() {
+export default function CreateServiceTitleScreen() {
   const {colorScheme, toggleColorScheme} = useColorScheme();
   const { t, i18n } = useTranslation();
   const iconColor = colorScheme === 'dark' ? '#706F6E' : '#B6B5B5';

--- a/Wisdom_expo/screens/services/CalendarScreen.js
+++ b/Wisdom_expo/screens/services/CalendarScreen.js
@@ -178,7 +178,7 @@ export default function CalendarScreen() {
               {t('calendar')}
             </Text>
           </View>
-          {/* <TouchableOpacity onPress={() => navigation.navigate('CreateService1')} className="p-[8px] bg-[#fcfcfc] dark:bg-[#323131] rounded-full">
+          {/* <TouchableOpacity onPress={() => navigation.navigate('CreateServiceStart')} className="p-[8px] bg-[#fcfcfc] dark:bg-[#323131] rounded-full">
             <Plus height={23} width={23} color={iconColor} strokeWidth={1.7}/>
           </TouchableOpacity> */}
         </View>


### PR DESCRIPTION
## Summary
- rename CreateService* and CollectionMethod* components to match new naming scheme
- update navigation imports and stack routes for the renamed screens
- fix calendar references to the new CreateServiceStart route

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c72785ed0832b805d4e1c2ffeba7d