### PR TITLE
Handle payment failures by redirecting to booking screens with modals

### DIFF
--- a/Wisdom_expo/screens/booking/BookingDetailsScreen.js
+++ b/Wisdom_expo/screens/booking/BookingDetailsScreen.js
@@ -51,6 +51,13 @@ export default function BookingDetailsScreen() {
   const [paymentErrorVisible, setPaymentErrorVisible] = useState(false);
 
   useEffect(() => {
+    if (route.params?.paymentError) {
+      setPaymentErrorVisible(true);
+      navigation.setParams({ paymentError: undefined });
+    }
+  }, [route.params?.paymentError]);
+
+  useEffect(() => {
     fetchBooking();
   }, []);
 

--- a/Wisdom_expo/screens/booking/BookingScreen.js
+++ b/Wisdom_expo/screens/booking/BookingScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef} from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, TouchableWithoutFeedback, RefreshControl, Alert } from 'react-native';
+import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, TouchableWithoutFeedback, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -51,7 +51,14 @@ export default function BookingScreen() {
   const [selectedTimeUndefined, setSelectedTimeUndefined] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
 
-  const [paymentErrorVisible, setPaymentErrorVisible] = useState(false);
+const [paymentErrorVisible, setPaymentErrorVisible] = useState(false);
+
+useEffect(() => {
+  if (route.params?.paymentError) {
+    setPaymentErrorVisible(true);
+    navigation.setParams({ paymentError: undefined });
+  }
+}, [route.params?.paymentError]);
   
   const [startDate, setStartDate] = useState();
   const [duration, setDuration] = useState();
@@ -504,10 +511,10 @@ export default function BookingScreen() {
         return;
       }
   
-      Alert.alert(t('payment_error'), t('payment_error_message'), [{ text: t('ok') }]);
+      setPaymentErrorVisible(true);
     } catch (e) {
       console.error('Booking payment error :', e);
-      Alert.alert(t('payment_error'), t('payment_error_message'), [{ text: t('ok') }]);
+      setPaymentErrorVisible(true);
     }
   };
 

--- a/Wisdom_expo/screens/booking/PaymentMethodScreen.js
+++ b/Wisdom_expo/screens/booking/PaymentMethodScreen.js
@@ -1,12 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, Keyboard, TouchableWithoutFeedback, ActivityIndicator, Alert } from 'react-native';import { useTranslation } from 'react-i18next';
+import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, Keyboard, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
+import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
 import { CreditCard } from 'react-native-feather';
 import { CardField, useStripe } from '@stripe/stripe-react-native';
-import api from '../../utils/api';
 import ModalMessage from '../../components/ModalMessage';
 
 export default function PaymentMethodScreen() {
@@ -28,6 +28,16 @@ export default function PaymentMethodScreen() {
   const paymentMethodId = route.params?.paymentMethodId;
 
   const [paymentErrorVisible, setPaymentErrorVisible] = useState(false);
+
+  const handlePaymentError = () => {
+    if (origin === 'Booking') {
+      navigation.navigate('Booking', { ...prevParams, bookingId, paymentError: true });
+    } else if (origin === 'BookingDetails') {
+      navigation.navigate('BookingDetails', { bookingId, role, paymentError: true });
+    } else {
+      setPaymentErrorVisible(true);
+    }
+  };
 
   const handleBack = () => {
     if (origin === 'Booking') {
@@ -57,7 +67,7 @@ export default function PaymentMethodScreen() {
       setProcessing(false);
       if (error) {
         console.log('Payment error', error);
-        Alert.alert(t('payment_error'), t('payment_error_message'), [{ text: t('ok') }]);
+        handlePaymentError();
         return;
       }
       if (onSuccess) navigation.navigate(onSuccess, bookingId ? { bookingId } : {});
@@ -75,7 +85,7 @@ export default function PaymentMethodScreen() {
       });
       if (error) {
         console.log('Payment method error', error);
-        Alert.alert(t('payment_error'), t('payment_error_message'), [{ text: t('ok') }]);
+        handlePaymentError();
         return;
       }
   
@@ -97,7 +107,7 @@ export default function PaymentMethodScreen() {
         if (confirmErr) {
           console.log('Confirm error', confirmErr);
           setProcessing(false);
-          Alert.alert(t('payment_error'), t('payment_error_message'), [{ text: t('ok') }]);
+          handlePaymentError();
           return;
         }
         setProcessing(false);
@@ -121,7 +131,7 @@ export default function PaymentMethodScreen() {
     } catch (e) {
       console.log('handleDone error', e);
       setProcessing(false);
-      Alert.alert(t('payment_error'), t('payment_error_message'), [{ text: t('ok') }]);
+      handlePaymentError();
     }
   };
 


### PR DESCRIPTION
## Summary
- Redirect users back to their booking screen when payment confirmation fails, avoiding the payment method screen.
- Display localized error modals on Booking and Booking Details screens instead of alerts.
- Wire payment error flags through navigation so screens can show the modal automatically.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a1aeb23e68832bba9ff6a74e844790