### PR TITLE
Align defaults in create service toggles

### DIFF
--- a/Wisdom_expo/screens/professional/create_service/CreateServiceAskScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceAskScreen.js
@@ -19,8 +19,9 @@ export default function CreateServiceAskScreen() {
   const route = useRoute();
   const prevParams = route.params?.prevParams || {};
   const { title, family, category, description, selectedLanguages, isIndividual, hobbies, tags, location, actionRate, experiences, serviceImages, priceType, priceValue, allowDiscounts, discountRate, allowAsk: prevAllowAsk } = prevParams;
-  const [typeSelected, setTypeSelected] = useState(prevAllowAsk ? 1 : 0);
-  const [allowAsk, setAllowAsk] = useState(prevAllowAsk ?? true);
+  const allowAskDefault = prevAllowAsk ?? true;
+  const [allowAsk, setAllowAsk] = useState(allowAskDefault);
+  const [typeSelected, setTypeSelected] = useState(allowAskDefault ? 1 : 0);
   
   const options  = [
     {

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceConsultScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceConsultScreen.js
@@ -19,8 +19,9 @@ export default function CreateServiceConsultScreen() {
   const route = useRoute();
   const prevParams = route.params?.prevParams || {};
   const { title, family, category, description, selectedLanguages, isIndividual, hobbies, tags, location, actionRate, experiences, serviceImages, priceType, priceValue, allowDiscounts, discountRate, allowAsk, allowConsults: prevAllowConsults, consultPrice: prevConsultPrice, consultVia: prevConsultVia } = prevParams;
-  const [typeSelected, setTypeSelected] = useState(prevAllowConsults ? 1 : 0);
-  const [allowConsults, setAllowConsults] = useState(prevAllowConsults ?? true);
+  const allowConsultsDefault = prevAllowConsults ?? true;
+  const [allowConsults, setAllowConsults] = useState(allowConsultsDefault);
+  const [typeSelected, setTypeSelected] = useState(allowConsultsDefault ? 1 : 0);
   const [consultPriceText, setConsultPriceText] = useState(String(prevConsultPrice ?? 5));
   const [consultPrice, setConsultPrice] = useState(prevConsultPrice ?? 5);
   const [consultVia, setConsultVia] = useState(prevConsultVia || '');

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDiscountsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDiscountsScreen.js
@@ -18,8 +18,9 @@ export default function CreateServiceDiscountsScreen() {
   const route = useRoute();
   const prevParams = route.params?.prevParams || {};
   const { title, family, category, description, selectedLanguages, isIndividual, hobbies, tags, location, actionRate, experiences, serviceImages, priceType, priceValue } = prevParams;
-  const [typeSelected, setTypeSelected] = useState(prevParams.allowDiscounts ? 1 : 0);
-  const [allowDiscounts, setAllowDiscounts] = useState(prevParams.allowDiscounts ?? true);
+  const allowDiscountsDefault = prevParams.allowDiscounts ?? true;
+  const [allowDiscounts, setAllowDiscounts] = useState(allowDiscountsDefault);
+  const [typeSelected, setTypeSelected] = useState(allowDiscountsDefault ? 1 : 0);
   const [discountRate, setDiscountRate] = useState(prevParams.discountRate ?? 10);
   const [discountRateText, setDiscountRateText] = useState(String(prevParams.discountRate ?? 10));
 
@@ -105,7 +106,11 @@ export default function CreateServiceDiscountsScreen() {
               
               <TouchableOpacity
               disabled={false}
-              onPress={() => navigation.navigate('CreateServicePrice', { prevParams: { ...prevParams, allowDiscounts, discountRate } })}
+              onPress={() =>
+                priceType === 'budget'
+                  ? navigation.navigate('CreateServicePriceType', { prevParams: { ...prevParams, allowDiscounts, discountRate } })
+                  : navigation.navigate('CreateServicePrice', { prevParams: { ...prevParams, allowDiscounts, discountRate } })
+              }
               style={{opacity: 1}}
               className="bg-[#e0e0e0] dark:bg-[#3d3d3d] w-1/4 h-[55px] rounded-full items-center justify-center" >
                   <Text className="font-inter-medium text-[15px] text-[#323131] dark:text-[#fcfcfc]">{t('back')}</Text>


### PR DESCRIPTION
## Summary
- Sync allowAsk radio with default state
- Ensure discount and consult toggles match their saved values
- Skip price screen when backing out of discounts for budget pricing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9b78b8f28832b8ca79a70d16b2ac8