### PR TITLE
feat: add fullscreen map view with dynamic zoom

### DIFF
--- a/Wisdom_expo/navigation/navigation.js
+++ b/Wisdom_expo/navigation/navigation.js
@@ -101,6 +101,7 @@ import DniCameraScreen from '../screens/professional/collection_method/DniCamera
 import CollectionMethodIbanScreen from '../screens/professional/collection_method/CollectionMethodIbanScreen';
 import CollectionMethodDirectionScreen from '../screens/professional/collection_method/CollectionMethodDirectionScreen';
 import CollectionMethodConfirmScreen from '../screens/professional/collection_method/CollectionMethodConfirmScreen';
+import FullScreenMapScreen from '../screens/common/FullScreenMapScreen';
 
 
 
@@ -184,6 +185,7 @@ export default function Navigation() {
         <Stack.Screen name="DisplayReviews" component={DisplayReviewsScreen} />
         <Stack.Screen name="AddReview" component={AddReviewScreen} />
         <Stack.Screen name="EnlargedImage" component={EnlargedImageScreen} />
+        <Stack.Screen name="FullScreenMap" component={FullScreenMapScreen} />
         <Stack.Screen name="BookingDetails" component={BookingDetailsScreen} />
         <Stack.Screen name="SetFinalPrice" component={SetFinalPriceScreen} />
         <Stack.Screen name="CalendarPro" component={CalendarProScreen} options={{ animation: 'none', gestureEnabled: false }} />

--- a/Wisdom_expo/screens/common/FullScreenMapScreen.js
+++ b/Wisdom_expo/screens/common/FullScreenMapScreen.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View, TouchableOpacity } from 'react-native';
+import MapView, { Marker, Circle } from 'react-native-maps';
+import { Minimize2 } from 'react-native-feather';
+import { useNavigation, useRoute } from '@react-navigation/native';
+import { useColorScheme } from 'nativewind';
+import { getRegionForRadius } from '../../utils/mapUtils';
+
+export default function FullScreenMapScreen() {
+  const navigation = useNavigation();
+  const route = useRoute();
+  const { colorScheme } = useColorScheme();
+  const iconColor = colorScheme === 'dark' ? '#f2f2f2' : '#444343';
+  const { location, actionRate = 0 } = route.params;
+  const latitude = location.latitude ?? location.lat;
+  const longitude = location.longitude ?? location.lng;
+
+  const region = actionRate && actionRate < 100
+    ? getRegionForRadius(latitude, longitude, actionRate)
+    : { latitude, longitude, latitudeDelta: 0.05, longitudeDelta: 0.03 };
+
+  return (
+    <View className="flex-1">
+      <MapView style={{ flex: 1 }} region={region}>
+        <Marker
+          coordinate={{ latitude, longitude }}
+          image={require('../../assets/MapMarker.png')}
+          anchor={{ x: 0.5, y: 1 }}
+          centerOffset={{ x: 0.5, y: -20 }}
+        />
+        {actionRate < 100 && (
+          <Circle
+            center={{ latitude, longitude }}
+            radius={actionRate * 1000}
+            strokeColor="rgba(182,181,181,0.8)"
+            fillColor="rgba(182,181,181,0.5)"
+            strokeWidth={2}
+          />
+        )}
+      </MapView>
+      <TouchableOpacity
+        onPress={() => navigation.goBack()}
+        style={{ position: 'absolute', top: 16, right: 16, backgroundColor: colorScheme === 'dark' ? '#3D3D3D' : '#FFFFFF', borderRadius: 20, padding: 6 }}
+      >
+        <Minimize2 width={16} height={16} color={iconColor} />
+      </TouchableOpacity>
+    </View>
+  );
+}

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceLocationScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceLocationScreen.js
@@ -5,8 +5,9 @@ import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
 import { useNavigation, useRoute, useFocusEffect, useIsFocused } from '@react-navigation/native';
 import { XMarkIcon, ChevronDownIcon, ChevronUpIcon } from 'react-native-heroicons/outline';
-import { Search, Check } from "react-native-feather";
+import { Search, Check, Maximize2 } from "react-native-feather";
 import MapView, { Marker, Circle } from 'react-native-maps';
+import { getRegionForRadius } from '../../../utils/mapUtils';
 import { storeDataLocally, getDataLocally } from '../../../utils/asyncStorage';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Slider from '@react-native-community/slider';
@@ -117,6 +118,15 @@ export default function CreateServiceLocationScreen() {
     }, [location])
   );
 
+  const mapRegion = actionRate < 100
+    ? getRegionForRadius(currentLocation.lat, currentLocation.lng, actionRate)
+    : {
+        latitude: currentLocation.lat,
+        longitude: currentLocation.lng,
+        latitudeDelta: 0.05,
+        longitudeDelta: 0.03,
+      };
+
   return (
     <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
@@ -151,36 +161,38 @@ export default function CreateServiceLocationScreen() {
           </TouchableOpacity>
 
           <View className="mb-2 justify-center items-center">
-            <MapView
-              style={{ height: 250, width: 300, borderRadius: 12, marginTop: 20 }}
-              region={{
-                latitude: currentLocation.lat, // Latitud inicial
-                longitude: currentLocation.lng, // Longitud inicial
-                latitudeDelta: 0.02, // Zoom en la latitud
-                longitudeDelta: 0.01, // Zoom en la longitud
-              }}
-            >
-              {/* Solo renderizar el marcador si 'location' existe */}
-              {location && (
-                <View>
-                  <Marker
-                    coordinate={{ latitude: currentLocation.lat, longitude: currentLocation.lng }}
-                    image={require('../../../assets/MapMarker.png')}
-                    anchor={{ x: 0.5, y: 1 }}
-                    centerOffset={{ x: 0.5, y: -20 }}
-                  />
-                  {actionRate < 100 && (
-                    <Circle
-                      center={{ latitude: currentLocation.lat, longitude: currentLocation.lng }}
-                      radius={actionRate * 1000}
-                      strokeColor="rgba(182,181,181,0.8)"
-                      fillColor="rgba(182,181,181,0.5)"
-                      strokeWidth={2}
+            <View style={{ marginTop: 20, position: 'relative' }}>
+              <MapView
+                style={{ height: 250, width: 300, borderRadius: 12 }}
+                region={mapRegion}
+              >
+                {location && (
+                  <View>
+                    <Marker
+                      coordinate={{ latitude: currentLocation.lat, longitude: currentLocation.lng }}
+                      image={require('../../../assets/MapMarker.png')}
+                      anchor={{ x: 0.5, y: 1 }}
+                      centerOffset={{ x: 0.5, y: -20 }}
                     />
-                  )}
-                </View>
-              )}
-            </MapView>
+                    {actionRate < 100 && (
+                      <Circle
+                        center={{ latitude: currentLocation.lat, longitude: currentLocation.lng }}
+                        radius={actionRate * 1000}
+                        strokeColor="rgba(182,181,181,0.8)"
+                        fillColor="rgba(182,181,181,0.5)"
+                        strokeWidth={2}
+                      />
+                    )}
+                  </View>
+                )}
+              </MapView>
+              <TouchableOpacity
+                onPress={() => navigation.navigate('FullScreenMap', { location: { latitude: currentLocation.lat, longitude: currentLocation.lng }, actionRate })}
+                style={{ position: 'absolute', top: 10, right: 10, backgroundColor: colorScheme === 'dark' ? '#3D3D3D' : '#FFFFFF', borderRadius: 20, padding: 6 }}
+              >
+                <Maximize2 width={16} height={16} color={colorScheme === 'dark' ? '#f2f2f2' : '#444343'} />
+              </TouchableOpacity>
+            </View>
           </View>
 
           {direction ? (

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
@@ -7,7 +7,8 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon, ChevronLeftIcon, GlobeAltIcon, GlobeEuropeAfricaIcon} from 'react-native-heroicons/outline';
 import MapView, { Marker, Circle } from 'react-native-maps';
 import StarFillIcon from 'react-native-bootstrap-icons/icons/star-fill';
-import {Heart} from 'react-native-feather';
+import {Heart, Maximize2} from 'react-native-feather';
+import { getRegionForRadius } from '../../../utils/mapUtils';
 import api from '../../../utils/api.js';
 import { getDataLocally } from '../../../utils/asyncStorage';
 import axios from 'axios';
@@ -118,6 +119,15 @@ export default function CreateServiceReviewScreen() {
         return null;
     }
   };
+
+  const mapRegion = location && actionRate < 100
+    ? getRegionForRadius(location.lat, location.lng, actionRate)
+    : {
+        latitude: location?.lat || 0,
+        longitude: location?.lng || 0,
+        latitudeDelta: 0.05,
+        longitudeDelta: 0.03,
+      };
 
   const getUserId = async () => {
     const userData = await getDataLocally('user');
@@ -371,38 +381,41 @@ export default function CreateServiceReviewScreen() {
             <View className='w-full'>
               <Text className="mb-7 font-inter-semibold text-[18px] text-[#444343] dark:text-[#f2f2f2]">Location</Text>
               <View className="justify-center items-center w-full">
-                <MapView
-                  style={{ height: 160, width: 280, borderRadius: 12 }}
-                  region={{
-                    latitude: location.lat,
-                    longitude: location.lng,
-                    latitudeDelta: 0.05,
-                    longitudeDelta: 0.03,
-                  }}
-                >
-                  {location && (
-                    <View>
-                      <Marker
-                        coordinate={{ latitude: location.lat, longitude: location.lng }}
-                        image={require('../../../assets/MapMarker.png')}
-                        anchor={{ x: 0.5, y: 1 }}
-                        centerOffset={{ x: 0.5, y: -20 }}
-                      />
-                      {actionRate < 100 && (
-                        <Circle
-                          center={{ latitude: location.lat, longitude: location.lng }}
-                          radius={actionRate * 1000}
-                          strokeColor="rgba(182,181,181,0.8)"
-                          fillColor="rgba(182,181,181,0.5)"
-                          strokeWidth={2}
+                <View style={{ position: 'relative' }}>
+                  <MapView
+                    style={{ height: 160, width: 280, borderRadius: 12 }}
+                    region={mapRegion}
+                  >
+                    {location && (
+                      <View>
+                        <Marker
+                          coordinate={{ latitude: location.lat, longitude: location.lng }}
+                          image={require('../../../assets/MapMarker.png')}
+                          anchor={{ x: 0.5, y: 1 }}
+                          centerOffset={{ x: 0.5, y: -20 }}
                         />
-                      )}
-                    </View>
-                  )}
-                </MapView>
+                        {actionRate < 100 && (
+                          <Circle
+                            center={{ latitude: location.lat, longitude: location.lng }}
+                            radius={actionRate * 1000}
+                            strokeColor="rgba(182,181,181,0.8)"
+                            fillColor="rgba(182,181,181,0.5)"
+                            strokeWidth={2}
+                          />
+                        )}
+                      </View>
+                    )}
+                  </MapView>
+                  <TouchableOpacity
+                    onPress={() => navigation.navigate('FullScreenMap', { location: { latitude: location.lat, longitude: location.lng }, actionRate })}
+                    style={{ position: 'absolute', top: 10, right: 10, backgroundColor: colorScheme === 'dark' ? '#3D3D3D' : '#FFFFFF', borderRadius: 20, padding: 6 }}
+                  >
+                    <Maximize2 width={16} height={16} color={colorScheme === 'dark' ? '#f2f2f2' : '#444343'} />
+                  </TouchableOpacity>
+                </View>
                 <View className="mt-3 px-3 w-full flex-row justify-between items-center">
-                <Text className="mt-3 font-inter-semibold text-[14px] text-[#706F6E] dark:text-[#b6b5b5]">{address ? address : 'Loading...'}</Text>
-                <Text className="mt-3 font-inter-semibold text-[14px] text-[#B6B5B5] dark:text-[#706F6E]">{localHour ? `${localHour} local hour` : ''}</Text>
+                  <Text className="mt-3 font-inter-semibold text-[14px] text-[#706F6E] dark:text-[#b6b5b5]">{address ? address : 'Loading...'}</Text>
+                  <Text className="mt-3 font-inter-semibold text-[14px] text-[#B6B5B5] dark:text-[#706F6E]">{localHour ? `${localHour} local hour` : ''}</Text>
                 </View>
               </View>
             </View>

--- a/Wisdom_expo/utils/mapUtils.js
+++ b/Wisdom_expo/utils/mapUtils.js
@@ -1,0 +1,12 @@
+export const getRegionForRadius = (latitude, longitude, radiusKm, marginFactor = 1.2) => {
+  const earthKmPerDegLat = 111; // approx
+  const latDelta = Math.max((radiusKm / earthKmPerDegLat) * 2 * marginFactor, 0.05);
+  const lonDegreeKm = earthKmPerDegLat * Math.cos(latitude * Math.PI / 180);
+  const lonDelta = Math.max((radiusKm / lonDegreeKm) * 2 * marginFactor, 0.03);
+  return {
+    latitude,
+    longitude,
+    latitudeDelta: latDelta,
+    longitudeDelta: lonDelta,
+  };
+};


### PR DESCRIPTION
## Summary
- add map utils to compute region based on action radius
- allow small maps to open fullscreen view with expand/minimize buttons
- auto-adjust map zoom to fit service radius with safe defaults

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc08f5b338832b95138091cbfe8e51