### PR TITLE
Update payout method terminology

### DIFF
--- a/Wisdom_expo/languages/en.json
+++ b/Wisdom_expo/languages/en.json
@@ -222,7 +222,7 @@
     "doing_this_will_delete_all_your_data": "Doing this will permanetly delete all your data",
     "bookings": "Bookings",
     "payment_methods": "Payment methods",
-    "collection_method": "Collection method",
+    "collection_method": "Payout method",
     "enter_your_name_and_dni": "Enter your name and ID number",
     "enter_your_name": "Enter your name",
     "enter_your_dni": "Enter your ID number",

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodConfirmScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodConfirmScreen.js
@@ -61,7 +61,7 @@ export default function CollectionMethodConfirmScreen() {
       }
       navigation.navigate('WalletPro');
     } catch (error) {
-      console.error('Error creating collection method:', error);
+      console.error('Error creating payout method:', error);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- replace the English locale label for collection_method with "Payout method"
- adjust the confirmation screen error log to reference payout methods

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d579f8d464832b906f713b25c293dc