### PR TITLE
Fix notification toggle, login input flicker, and consult panel visibility

### DIFF
--- a/Wisdom_expo/screens/professional/SettingsProScreen.js
+++ b/Wisdom_expo/screens/professional/SettingsProScreen.js
@@ -6,7 +6,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
-import { getTokens, clearTokens } from '../../utils/api.js';
+import api, { getTokens, clearTokens } from '../../utils/api.js';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 import eventEmitter from '../../utils/eventEmitter';
 import * as Notifications from 'expo-notifications';

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
@@ -483,26 +483,28 @@ export default function CreateServiceReviewScreen() {
         </View>
       </View>
 
-      <View className="mt-8 justify-center items-start pb-7 ">
-        <View className="mr-2 py-5 px-4 w-full bg-[#e0e0e0] dark:bg-[#323131] rounded-2xl">
-          <Text className="mb-4 font-inter-semibold text-[18px] text-[#444343] dark:text-[#f2f2f2]">Consult a professional</Text>
-          {consultPrice && (
-            <Text className=" font-inter-semibold text-[13px] text-[#706F6E] dark:text-[#b6b5b5]">{parseFloat(consultPrice).toFixed(0)} € for a 15 min call</Text>
-          )}
-          <View className="mt-8 flex-row justify-center items-center">
-            {allowAsk && (
-              <TouchableOpacity disabled style={{ opacity: 1 }} className={`mr-2 bg-[#E0E0E0] dark:bg-[#3d3d3d] ${!allowConsults ? 'w-full' : 'w-1/3'} h-[40] rounded-full items-center justify-center`}>
-                <Text className="font-inter-semibold text-[13px] text-[#444343] dark:text-[#f2f2f2]">{t('write')}</Text>
-              </TouchableOpacity>
+      {(allowAsk || allowConsults) && (
+        <View className="mt-8 justify-center items-start pb-7 ">
+          <View className="mr-2 py-5 px-4 w-full bg-[#e0e0e0] dark:bg-[#323131] rounded-2xl">
+            <Text className="mb-4 font-inter-semibold text-[18px] text-[#444343] dark:text-[#f2f2f2]">Consult a professional</Text>
+            {consultPrice && (
+              <Text className=" font-inter-semibold text-[13px] text-[#706F6E] dark:text-[#b6b5b5]">{parseFloat(consultPrice).toFixed(0)} € for a 15 min call</Text>
             )}
-            {allowConsults && (
-              <TouchableOpacity disabled style={{ opacity: 1 }} className={`bg-[#444343] dark:bg-[#f2f2f2] ${!allowAsk ? 'w-full' : 'w-2/3'} h-[40] rounded-full items-center justify-center`}>
-                <Text className="font-inter-semibold text-[13px] text-[#f2f2f2] dark:text-[#272626]">{t('book_a_consult')}</Text>
-              </TouchableOpacity>
-            )}
+            <View className="mt-8 flex-row justify-center items-center">
+              {allowAsk && (
+                <TouchableOpacity disabled style={{ opacity: 1 }} className={`mr-2 bg-[#E0E0E0] dark:bg-[#3d3d3d] ${!allowConsults ? 'w-full' : 'w-1/3'} h-[40] rounded-full items-center justify-center`}>
+                  <Text className="font-inter-semibold text-[13px] text-[#444343] dark:text-[#f2f2f2]">{t('write')}</Text>
+                </TouchableOpacity>
+              )}
+              {allowConsults && (
+                <TouchableOpacity disabled style={{ opacity: 1 }} className={`bg-[#444343] dark:bg-[#f2f2f2] ${!allowAsk ? 'w-full' : 'w-2/3'} h-[40] rounded-full items-center justify-center`}>
+                  <Text className="font-inter-semibold text-[13px] text-[#f2f2f2] dark:text-[#272626]">{t('book_a_consult')}</Text>
+                </TouchableOpacity>
+              )}
+            </View>
           </View>
         </View>
-      </View>
+      )}
 
     </View>
   );

--- a/Wisdom_expo/screens/start/LogInScreen.js
+++ b/Wisdom_expo/screens/start/LogInScreen.js
@@ -35,15 +35,13 @@ export default function LogInScreen() {
 
   
 
-  const inputPasswordChanged = (event) => {
-    const newPassword = event.nativeEvent.text;
-    setPassword (newPassword);
+  const inputPasswordChanged = (newPassword) => {
+    setPassword(newPassword);
     setShowError(false);
   }
 
-  const inputuserChanged = (event) => {
-    const newuser = event.nativeEvent.text;
-    setuser (newuser);
+  const inputuserChanged = (newuser) => {
+    setuser(newuser);
     setShowError(false);
   }
 
@@ -135,7 +133,7 @@ export default function LogInScreen() {
             autoFocus={true} 
             selectionColor={cursorColorChange} 
             placeholderTextColor={placeHolderTextColorChange} 
-            onChange = {inputuserChanged} 
+            onChangeText={inputuserChanged}
             value={userEmail}
             onSubmitEditing={nextPressed}
             keyboardType="email-address"
@@ -152,7 +150,7 @@ export default function LogInScreen() {
             selectionColor={cursorColorChange}
             placeholderTextColor={placeHolderTextColorChange}
             secureTextEntry={isSecure} // Controla la visibilidad del texto
-            onChange = {inputPasswordChanged} 
+            onChangeText={inputPasswordChanged}
             value={password}
             onSubmitEditing={nextPressed}
             keyboardAppearance={colorScheme === 'dark' ? 'dark' : 'light'}


### PR DESCRIPTION
## Summary
- import the shared API client into the professional settings screen so the notification toggle can call the backend without crashing
- replace onChange handlers with onChangeText in the login screen to prevent the email field from flickering while typing
- hide the consult panel on the create service review screen when neither writing nor consulting options are enabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d57b7573c0832b9ab4cffa45a92f6e