### PR TITLE
Replace SafeAreaView with safe-area-context in screens

### DIFF
--- a/Wisdom_expo/screens/booking/BookingDetailsScreen.js
+++ b/Wisdom_expo/screens/booking/BookingDetailsScreen.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useMemo } from 'react';
 import * as Localization from 'expo-localization';
-import { View, Text, SafeAreaView, Platform, StatusBar, TouchableOpacity, TextInput, ScrollView, Alert, Image, RefreshControl } from 'react-native';
+import { View, Text, Platform, StatusBar, TouchableOpacity, TextInput, ScrollView, Alert, Image, RefreshControl } from 'react-native';
 import RBSheet from 'react-native-raw-bottom-sheet';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
@@ -19,6 +19,7 @@ import { setDoc, doc, serverTimestamp, arrayRemove } from 'firebase/firestore';
 import { db } from '../../utils/firebase';
 import api from '../../utils/api.js';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import ModalMessage from '../../components/ModalMessage';
 
 export default function BookingDetailsScreen() {

--- a/Wisdom_expo/screens/booking/BookingScreen.js
+++ b/Wisdom_expo/screens/booking/BookingScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, TouchableWithoutFeedback, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, TouchableWithoutFeedback, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -21,6 +21,7 @@ import SliderThumbDark from '../../assets/SliderThumbDark.png';
 import SliderThumbLight from '../../assets/SliderThumbLight.png';
 import { format } from 'date-fns';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import ModalMessage from '../../components/ModalMessage';
 
 

--- a/Wisdom_expo/screens/booking/PaymentMethodScreen.js
+++ b/Wisdom_expo/screens/booking/PaymentMethodScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, Keyboard, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, Keyboard, TouchableWithoutFeedback, ActivityIndicator } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -7,6 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
 import { CreditCard } from 'react-native-feather';
 import { CardField, useStripe } from '@stripe/stripe-react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import ModalMessage from '../../components/ModalMessage';
 
 export default function PaymentMethodScreen() {

--- a/Wisdom_expo/screens/booking/SetFinalPriceScreen.js
+++ b/Wisdom_expo/screens/booking/SetFinalPriceScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { SafeAreaView, StatusBar, Platform, View, Text, TouchableOpacity, TextInput, Keyboard, TouchableWithoutFeedback, Alert } from 'react-native';
+import { StatusBar, Platform, View, Text, TouchableOpacity, TextInput, Keyboard, TouchableWithoutFeedback, Alert } from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { useColorScheme } from 'nativewind';
 import { useTranslation } from 'react-i18next';
@@ -7,6 +7,7 @@ import '../../languages/i18n';
 import { XMarkIcon, ChevronDownIcon, ChevronUpIcon } from 'react-native-heroicons/outline';
 import { Edit3 } from 'react-native-feather';
 import api from '../../utils/api';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function SetFinalPriceScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/chat/ChatImageViewerScreen.js
+++ b/Wisdom_expo/screens/chat/ChatImageViewerScreen.js
@@ -1,10 +1,11 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, FlatList, Image, Dimensions, Animated } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, FlatList, Image, Dimensions, Animated } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { useColorScheme } from 'nativewind';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ChatImageViewerScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/chat/ChatScreen.js
+++ b/Wisdom_expo/screens/chat/ChatScreen.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useCallback, useRef } from 'react';
 import {
   View,
   StatusBar,
-  SafeAreaView,
   Platform,
   TouchableOpacity,
   Text,
@@ -26,6 +25,7 @@ import { collection, query, where, orderBy, onSnapshot, doc, updateDoc, arrayUni
 import { SwipeListView } from 'react-native-swipe-list-view';
 import defaultProfilePic from '../../assets/defaultProfilePic.jpg';
 import { db } from '../../utils/firebase';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 
 

--- a/Wisdom_expo/screens/favorites/FavoritesScreen.js
+++ b/Wisdom_expo/screens/favorites/FavoritesScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, Text, TouchableOpacity, ScrollView, FlatList, Alert, Image, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, Text, TouchableOpacity, ScrollView, FlatList, Alert, Image, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -9,6 +9,7 @@ import { BookmarkIcon } from 'react-native-heroicons/solid';
 import { getDataLocally } from '../../utils/asyncStorage';
 import api from '../../utils/api.js';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { formatDistanceToNowStrict } from 'date-fns';
 
 export default function FavoritesScreen() {

--- a/Wisdom_expo/screens/favorites/ListScreen.js
+++ b/Wisdom_expo/screens/favorites/ListScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useRef, useCallback } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, Text, TouchableOpacity, FlatList, TextInput, Image, Alert, StyleSheet, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, Text, TouchableOpacity, FlatList, TextInput, Image, Alert, StyleSheet, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -11,6 +11,7 @@ import api from '../../utils/api.js';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 import RBSheet from 'react-native-raw-bottom-sheet';
 import BookMarksFillIcon from 'react-native-bootstrap-icons/icons/bookmarks-fill';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ListScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/home/AddReviewScreen.js
+++ b/Wisdom_expo/screens/home/AddReviewScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { View, Text, SafeAreaView, Platform, StatusBar, TouchableOpacity, TextInput, TouchableWithoutFeedback, Keyboard } from 'react-native';
+import { View, Text, Platform, StatusBar, TouchableOpacity, TextInput, TouchableWithoutFeedback, Keyboard } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -7,6 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import StarFillIcon from 'react-native-bootstrap-icons/icons/star-fill';
 import api from '../../utils/api.js';
 import { getDataLocally } from '../../utils/asyncStorage';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function AddReviewScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/home/ConfirmDirectionScreen.js
+++ b/Wisdom_expo/screens/home/ConfirmDirectionScreen.js
@@ -1,9 +1,10 @@
 
 import React, { useEffect } from 'react'
-import {View, StatusBar, SafeAreaView, Platform} from 'react-native';
+import {View, StatusBar, Platform} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 
 

--- a/Wisdom_expo/screens/home/ConfirmPaymentScreen.js
+++ b/Wisdom_expo/screens/home/ConfirmPaymentScreen.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -9,6 +9,7 @@ import api from '../../utils/api.js';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
 import { Buffer } from 'buffer';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function ConfirmPaymentScreen() {

--- a/Wisdom_expo/screens/home/DisplayImagesScreen.js
+++ b/Wisdom_expo/screens/home/DisplayImagesScreen.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, FlatList, Image } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, FlatList, Image } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { useColorScheme } from 'nativewind';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function DisplayImagesScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/home/DisplayReviewsScreen.js
+++ b/Wisdom_expo/screens/home/DisplayReviewsScreen.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, FlatList, Image } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, FlatList, Image } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { useColorScheme } from 'nativewind';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import StarFillIcon from 'react-native-bootstrap-icons/icons/star-fill';
 
 export default function DisplayReviewsScreen() {

--- a/Wisdom_expo/screens/home/EnlargedImageScreen.js
+++ b/Wisdom_expo/screens/home/EnlargedImageScreen.js
@@ -1,10 +1,11 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, FlatList, Image, Dimensions, Animated } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, FlatList, Image, Dimensions, Animated } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { useColorScheme } from 'nativewind';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function EnlargedImageScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/home/HomeScreen.js
+++ b/Wisdom_expo/screens/home/HomeScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, ImageBackground, Button, TouchableWithoutFeedback, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, ImageBackground, Button, TouchableWithoutFeedback, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -18,6 +18,7 @@ import SliderThumbDark from '../../assets/SliderThumbDark.png';
 import SliderThumbLight from '../../assets/SliderThumbLight.png';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { BlurView } from 'expo-blur';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { format } from 'date-fns';
 
 

--- a/Wisdom_expo/screens/home/ResultsScreen.js
+++ b/Wisdom_expo/screens/home/ResultsScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -14,6 +14,7 @@ import HeartFill from "../../assets/HeartFill.tsx"
 import WisdomLogo from '../../assets/wisdomLogo.tsx'
 import api from '../../utils/api.js';
 import RBSheet from 'react-native-raw-bottom-sheet';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 
 

--- a/Wisdom_expo/screens/home/SearchDirectionScreen.js
+++ b/Wisdom_expo/screens/home/SearchDirectionScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Alert, Linking } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Alert, Linking } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -12,6 +12,7 @@ import * as Location from 'expo-location';
 import RBSheet from 'react-native-raw-bottom-sheet';
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import api from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/home/SearchScreen.js
+++ b/Wisdom_expo/screens/home/SearchScreen.js
@@ -1,9 +1,10 @@
 
 import React, { useEffect } from 'react'
-import {View, StatusBar, SafeAreaView, Platform} from 'react-native';
+import {View, StatusBar, Platform} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
 
 

--- a/Wisdom_expo/screens/home/SearchServiceScreen.js
+++ b/Wisdom_expo/screens/home/SearchServiceScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, StyleSheet } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -9,6 +9,7 @@ import { Search, Clock, MapPin } from "react-native-feather";
 import * as Location from 'expo-location';
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import api from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function SearchServiceScreen() {
 

--- a/Wisdom_expo/screens/home/ServiceProfileScreen.js
+++ b/Wisdom_expo/screens/home/ServiceProfileScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableWithoutFeedback, TouchableOpacity, Keyboard, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, Alert, RefreshControl, Linking } from 'react-native';
+import { View, StatusBar, Platform, TouchableWithoutFeedback, TouchableOpacity, Keyboard, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, Alert, RefreshControl, Linking } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -34,6 +34,7 @@ import {
   mapMarkerCenterOffset,
   mapMarkerImage,
   mapMarkerStyle,
+import { SafeAreaView } from 'react-native-safe-area-context';
 } from '../../utils/mapMarkerAssets';
 
 

--- a/Wisdom_expo/screens/professional/CalendarProScreen.js
+++ b/Wisdom_expo/screens/professional/CalendarProScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef} from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -11,6 +11,7 @@ import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import SuitcaseFill from "../../assets/SuitcaseFill.tsx"
 import api from '../../utils/api.js';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Calendar } from 'react-native-calendars';
 
 

--- a/Wisdom_expo/screens/professional/ListingsProScreen.js
+++ b/Wisdom_expo/screens/professional/ListingsProScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -11,6 +11,7 @@ import { getDataLocally } from '../../utils/asyncStorage';
 import SuitcaseFill from "../../assets/SuitcaseFill.tsx"
 import api from '../../utils/api.js';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import Message from '../../components/Message';
 
 

--- a/Wisdom_expo/screens/professional/SettingsProScreen.js
+++ b/Wisdom_expo/screens/professional/SettingsProScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { Text, View, Button, AppState, Switch, Platform, StatusBar, SafeAreaView, ScrollView, TouchableOpacity, Image, Linking, RefreshControl, Alert } from 'react-native';
+import { Text, View, Button, AppState, Switch, Platform, StatusBar, ScrollView, TouchableOpacity, Image, Linking, RefreshControl, Alert } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -17,6 +17,7 @@ import { KeyIcon, ChevronRightIcon, ArrowsRightLeftIcon } from 'react-native-her
 import GiftCardIcon from '../../assets/GiftCard';
 import ExpertIcon from '../../assets/Expert';
 import CashStackIcon from '../../assets/CashStack';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import SuticasePlusIcon from '../../assets/SuitcasePlus';
 
 

--- a/Wisdom_expo/screens/professional/TodayProScreen.js
+++ b/Wisdom_expo/screens/professional/TodayProScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -9,6 +9,7 @@ import { XMarkIcon, ChevronDownIcon, ChevronUpIcon, ChevronLeftIcon, ChevronRigh
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import api from '../../utils/api.js';
 import Clipboard from "../../assets/Clipboard";
+import { SafeAreaView } from 'react-native-safe-area-context';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 
 

--- a/Wisdom_expo/screens/professional/WalletProScreen.js
+++ b/Wisdom_expo/screens/professional/WalletProScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef} from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -10,6 +10,7 @@ import { XMarkIcon, ChevronDownIcon, ChevronUpIcon, ChevronLeftIcon, ChevronRigh
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import WisdomLogo from '../../assets/wisdomLogo'
 import api from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 
 

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodBirthScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodBirthScreen.js
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import DateTimePicker from '@react-native-community/datetimepicker';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
 
 export default function CollectionMethodBirthScreen() {

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodConfirmScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodConfirmScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, ScrollView, ActivityIndicator } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, ScrollView, ActivityIndicator } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../../languages/i18n';
@@ -7,6 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
 import api from '../../../utils/api.js';
 import { getDataLocally, storeDataLocally } from '../../../utils/asyncStorage';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function CollectionMethodConfirmScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodDirectionScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodDirectionScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, ScrollView, FlatList, Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, ScrollView, FlatList, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../../languages/i18n';
@@ -7,6 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon, ChevronDownIcon, ChevronUpIcon } from 'react-native-heroicons/outline';
 import Triangle from '../../../assets/triangle';
 import { formatE164IfMissing } from '../../../utils/phone';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function CollectionMethodDirectionScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodDniScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodDniScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, Image, Keyboard, TouchableWithoutFeedback, Alert, Linking } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, Image, Keyboard, TouchableWithoutFeedback, Alert, Linking } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../../languages/i18n';
@@ -7,6 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
 import PersonFill from "react-native-bootstrap-icons/icons/person-fill";
 import eventEmitter from '../../../utils/eventEmitter';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
 
 export default function CollectionMethodDniScreen() {

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodIbanScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodIbanScreen.js
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { XMarkIcon, ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function CollectionMethodIbanScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodNameScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodNameScreen.js
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../../languages/i18n';
 import { useNavigation } from '@react-navigation/native';
 import { XMarkIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function CollectionMethodNameScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodPhoneScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodPhoneScreen.js
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function CollectionMethodPhoneScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/professional/collection_method/DniCameraScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/DniCameraScreen.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef } from 'react';
-import { View, Text, TouchableOpacity, Dimensions, Platform, StatusBar, SafeAreaView } from 'react-native';
+import { View, Text, TouchableOpacity, Dimensions, Platform, StatusBar} from 'react-native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { useColorScheme } from 'nativewind';
 import { useTranslation } from 'react-i18next';
@@ -7,6 +7,7 @@ import '../../../languages/i18n';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import Svg, { Rect, Defs, Mask } from 'react-native-svg';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import eventEmitter from '../../../utils/eventEmitter';
 
 export default function DniCameraScreen() {

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceAskScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceAskScreen.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState, useRef } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, TouchableWithoutFeedback, Keyboard} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, TouchableWithoutFeedback, Keyboard} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon, ChevronDownIcon, ChevronUpIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Edit3 } from 'react-native-feather';
 
 

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceClassificationScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceClassificationScreen.js
@@ -2,7 +2,6 @@ import React, { useEffect, useState, useRef } from 'react';
 import {
   View,
   StatusBar,
-  SafeAreaView,
   Platform,
   TouchableOpacity,
   Text,
@@ -18,6 +17,7 @@ import {
   ChevronUpIcon,
 } from 'react-native-heroicons/outline';
 import Triangle from '../../../assets/triangle';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import api from '../../../utils/api.js';
 
 

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceConsultScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceConsultScreen.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState, useRef } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, TouchableWithoutFeedback, Keyboard} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, TouchableWithoutFeedback, Keyboard} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon, ChevronDownIcon, ChevronUpIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Edit3 } from 'react-native-feather';
 
 

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDescriptionScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDescriptionScreen.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef  } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, ScrollView, Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, ScrollView, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../../languages/i18n';
 import { useColorScheme } from 'nativewind';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { XMarkIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function CreateServiceDescriptionScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDetailsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDetailsScreen.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState, useRef } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Keyboard, TouchableWithoutFeedback} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Keyboard, TouchableWithoutFeedback} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon, ChevronDownIcon, ChevronUpIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Check } from "react-native-feather";
 
 

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDiscountsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDiscountsScreen.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon, ChevronDownIcon, ChevronUpIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function CreateServiceDiscountsScreen() {

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceExperiencesScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceExperiencesScreen.js
@@ -1,10 +1,11 @@
 import React, { useState, useEffect } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, ScrollView, Keyboard, StyleSheet } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, ScrollView, Keyboard, StyleSheet } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../../languages/i18n';
 import { useColorScheme } from 'nativewind';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { XMarkIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import DateTimePicker from '@react-native-community/datetimepicker';
 
 

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceImagesScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceImagesScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, ScrollView, Image, StyleSheet, Alert, Linking } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, ScrollView, Image, StyleSheet, Alert, Linking } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../../languages/i18n';
 import { useColorScheme } from 'nativewind';
@@ -7,6 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { XMarkIcon } from 'react-native-heroicons/outline'; // Asegúrate de importar PlusIcon o el ícono que prefieras
 import AddMainImage from '../../../assets/AddMainImage';
 import AddServiceImages from '../../../assets/AddServiceImages';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import * as ImagePicker from 'expo-image-picker';
 
 const patternImages = (images, colorScheme, onRemoveImage) => {

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceLocationScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceLocationScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, Image } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, Image } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
@@ -13,6 +13,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import Slider from '@react-native-community/slider';
 import SliderThumbDark from '../../../assets/SliderThumbDark.png';
 import SliderThumbLight from '../../../assets/SliderThumbLight.png';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   mapMarkerAnchor,
   mapMarkerCenterOffset,

--- a/Wisdom_expo/screens/professional/create_service/CreateServicePriceScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServicePriceScreen.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, Keyboard, TouchableWithoutFeedback } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { XMarkIcon, ChevronDownIcon, ChevronUpIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Edit3 } from 'react-native-feather';
 
 export default function CreateServicePriceScreen() {

--- a/Wisdom_expo/screens/professional/create_service/CreateServicePriceTypeScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServicePriceTypeScreen.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon, ChevronDownIcon, ChevronUpIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function CreateServicePriceTypeScreen() {

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, ScrollView, Image} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, ScrollView, Image} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
@@ -17,6 +17,7 @@ import {
   mapMarkerCenterOffset,
   mapMarkerImage,
   mapMarkerStyle,
+import { SafeAreaView } from 'react-native-safe-area-context';
 } from '../../../utils/mapMarkerAssets';
 
 

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceStartScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceStartScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useCallback } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
@@ -7,6 +7,7 @@ import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { storeDataLocally, getDataLocally } from '../../../utils/asyncStorage';
 
 import {XMarkIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceTermsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceTermsScreen.js
@@ -1,10 +1,11 @@
 import React, { useEffect } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon, ChevronLeftIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceTitleScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceTitleScreen.js
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {XMarkIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/services/CalendarScreen.js
+++ b/Wisdom_expo/screens/services/CalendarScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -11,6 +11,7 @@ import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import SuitcaseFill from "../../assets/SuitcaseFill.tsx"
 import api from '../../utils/api.js';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { Calendar } from 'react-native-calendars';
 
 

--- a/Wisdom_expo/screens/services/ServicesScreen.js
+++ b/Wisdom_expo/screens/services/ServicesScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef} from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -9,6 +9,7 @@ import { Calendar } from "react-native-feather";
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import api from '../../utils/api.js';
 import Clipboard from "../../assets/Clipboard";
+import { SafeAreaView } from 'react-native-safe-area-context';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 
 export default function ServicesScreen() {

--- a/Wisdom_expo/screens/settings/CancellationPolicyScreen.js
+++ b/Wisdom_expo/screens/settings/CancellationPolicyScreen.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import { View, StatusBar, SafeAreaView, Platform, ScrollView, Text, TouchableOpacity } from 'react-native';
+import { View, StatusBar, Platform, ScrollView, Text, TouchableOpacity } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
 import { useNavigation } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function CancellationPolicyScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/settings/ChangePasswordScreen.js
+++ b/Wisdom_expo/screens/settings/ChangePasswordScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, SafeAreaView, StatusBar, Platform, Text, TouchableOpacity, TextInput, Keyboard, Alert } from 'react-native';
+import { View, StatusBar, Platform, Text, TouchableOpacity, TextInput, Keyboard, Alert } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { useColorScheme } from 'nativewind';
@@ -9,6 +9,7 @@ import EyeIcon from 'react-native-bootstrap-icons/icons/eye';
 import EyeSlashIcon from 'react-native-bootstrap-icons/icons/eye-slash';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { getDataLocally } from '../../utils/asyncStorage';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import api from '../../utils/api';
 
 export default function ChangePasswordScreen() {

--- a/Wisdom_expo/screens/settings/DirectionsScreen.js
+++ b/Wisdom_expo/screens/settings/DirectionsScreen.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef} from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -9,6 +9,7 @@ import { XMarkIcon, ChevronDownIcon, ChevronUpIcon, ChevronLeftIcon, ChevronRigh
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import WisdomLogo from '../../assets/wisdomLogo.tsx'
 import api from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import RBSheet from 'react-native-raw-bottom-sheet';
 
 

--- a/Wisdom_expo/screens/settings/EditAccountScreen.js
+++ b/Wisdom_expo/screens/settings/EditAccountScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, Keyboard, ActivityIndicator, Alert, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, Keyboard, ActivityIndicator, Alert, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -12,6 +12,7 @@ import api from '../../utils/api.js';
 import { CheckCircleIcon, XCircleIcon } from 'react-native-heroicons/solid';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 import * as ImagePicker from 'expo-image-picker';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import axios from 'axios';
 
 

--- a/Wisdom_expo/screens/settings/EditProfileScreen.js
+++ b/Wisdom_expo/screens/settings/EditProfileScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef } from 'react'
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, Keyboard, Linking, ActivityIndicator, Alert, RefreshControl } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, TextInput, StyleSheet, FlatList, ScrollView, Image, KeyboardAvoidingView, Keyboard, Linking, ActivityIndicator, Alert, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -12,6 +12,7 @@ import api from '../../utils/api.js';
 import { CheckCircleIcon, XCircleIcon } from 'react-native-heroicons/solid';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 import * as ImagePicker from 'expo-image-picker';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import eventEmitter from '../../utils/eventEmitter';
 
 

--- a/Wisdom_expo/screens/settings/ExpertPlansScreen.js
+++ b/Wisdom_expo/screens/settings/ExpertPlansScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef} from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -10,6 +10,7 @@ import { XMarkIcon, ChevronDownIcon, ChevronUpIcon, ChevronLeftIcon, ChevronRigh
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import WisdomLogo from '../../assets/wisdomLogo.tsx'
 import api from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function ExpertPlansScreen() {

--- a/Wisdom_expo/screens/settings/FAQScreen.js
+++ b/Wisdom_expo/screens/settings/FAQScreen.js
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, ScrollView } from 'react-native';
+import { View, StatusBar, Platform, TouchableOpacity, Text, ScrollView } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { useColorScheme } from 'nativewind';
 import { useNavigation } from '@react-navigation/native';
 import { ChevronDownIcon, ChevronUpIcon, ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function FAQScreen() {

--- a/Wisdom_expo/screens/settings/HelpScreen.js
+++ b/Wisdom_expo/screens/settings/HelpScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef} from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, Linking} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, Linking} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -10,6 +10,7 @@ import { XMarkIcon, ChevronDownIcon, ChevronUpIcon, ChevronLeftIcon, ChevronRigh
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import WisdomLogo from '../../assets/wisdomLogo.tsx'
 import api from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/settings/LanguageScreen.js
+++ b/Wisdom_expo/screens/settings/LanguageScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Text, View, StatusBar, SafeAreaView, ScrollView, TouchableOpacity, Platform, RefreshControl } from 'react-native';
+import { Text, View, StatusBar, ScrollView, TouchableOpacity, Platform, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
@@ -9,6 +9,7 @@ import { ChevronLeftIcon } from 'react-native-heroicons/outline';
 import { MaterialIcons } from '@expo/vector-icons';
 import { Check } from "react-native-feather";
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/settings/PreferencesScreen.js
+++ b/Wisdom_expo/screens/settings/PreferencesScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useState, useCallback } from 'react';
-import { Text, View, Button, Switch, Platform, StatusBar, SafeAreaView, ScrollView, TouchableOpacity, RefreshControl } from 'react-native';
+import { Text, View, Button, Switch, Platform, StatusBar, ScrollView, TouchableOpacity, RefreshControl } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { storeDataLocally } from '../../utils/asyncStorage';
 import { useColorScheme } from 'nativewind'
@@ -8,6 +8,7 @@ import '../../languages/i18n';
 import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import {ChevronRightIcon, ChevronLeftIcon} from 'react-native-heroicons/outline';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/settings/ReservationPolicyScreen.js
+++ b/Wisdom_expo/screens/settings/ReservationPolicyScreen.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import { View, StatusBar, SafeAreaView, Platform, ScrollView, Text, TouchableOpacity } from 'react-native';
+import { View, StatusBar, Platform, ScrollView, Text, TouchableOpacity } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
 import { useNavigation } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function ReservationPolicyScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/settings/SettingsScreen.js
+++ b/Wisdom_expo/screens/settings/SettingsScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { Text, View, AppState, Button, Switch, Platform, StatusBar, SafeAreaView, ScrollView, TouchableOpacity, Image, Linking, RefreshControl, Alert } from 'react-native';
+import { Text, View, AppState, Button, Switch, Platform, StatusBar, ScrollView, TouchableOpacity, Image, Linking, RefreshControl, Alert } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -19,6 +19,7 @@ import { KeyIcon, ChevronRightIcon, ArrowsRightLeftIcon } from 'react-native-her
 import GiftCardIcon from '../../assets/GiftCard';
 import ExpertIcon from '../../assets/Expert';
 import CashStackIcon from '../../assets/CashStack';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import SuticasePlusIcon from '../../assets/SuitcasePlus';
 
 

--- a/Wisdom_expo/screens/settings/TurnExpertScreen.js
+++ b/Wisdom_expo/screens/settings/TurnExpertScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef} from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -10,6 +10,7 @@ import { XMarkIcon, ChevronDownIcon, ChevronUpIcon, ChevronLeftIcon, ChevronRigh
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import WisdomLogo from '../../assets/wisdomLogo.tsx'
 import api from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function TurnExpertScreen() {

--- a/Wisdom_expo/screens/settings/WalletScreen.js
+++ b/Wisdom_expo/screens/settings/WalletScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState, useCallback, useRef} from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, TextInput, FlatList, ScrollView, Image, RefreshControl} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
@@ -10,6 +10,7 @@ import { XMarkIcon, ChevronDownIcon, ChevronUpIcon, ChevronLeftIcon, ChevronRigh
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import WisdomLogo from '../../assets/wisdomLogo.tsx'
 import api from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import useRefreshOnFocus from '../../utils/useRefreshOnFocus';
 
 

--- a/Wisdom_expo/screens/settings/WisdomWarrantyScreen.js
+++ b/Wisdom_expo/screens/settings/WisdomWarrantyScreen.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import { View, StatusBar, SafeAreaView, Platform, ScrollView, Text, TouchableOpacity } from 'react-native';
+import { View, StatusBar, Platform, ScrollView, Text, TouchableOpacity } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind';
 import '../../languages/i18n';
 import { useNavigation } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function WisdomWarrantyScreen() {
   const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/start/CreateProfileScreen.js
+++ b/Wisdom_expo/screens/start/CreateProfileScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { SafeAreaView, View, Text, Linking, TextInput, KeyboardAvoidingView, TouchableOpacity, Image, Platform, StatusBar,  Alert, ActivityIndicator, TouchableWithoutFeedback, Keyboard } from 'react-native';
+import { View, Text, Linking, TextInput, KeyboardAvoidingView, TouchableOpacity, Image, Platform, StatusBar,  Alert, ActivityIndicator, TouchableWithoutFeedback, Keyboard } from 'react-native';
 import * as ImagePicker from 'expo-image-picker';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useTranslation } from 'react-i18next';
@@ -11,6 +11,7 @@ import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import api from '../../utils/api';
 import { CheckCircleIcon, XCircleIcon } from 'react-native-heroicons/solid';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view'
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function CreateProfileScreen() {
     const { colorScheme } = useColorScheme();

--- a/Wisdom_expo/screens/start/EmailSendedScreen.js
+++ b/Wisdom_expo/screens/start/EmailSendedScreen.js
@@ -1,12 +1,13 @@
 
 
 import React from 'react';
-import {View, StatusBar, SafeAreaView, Platform, Text, TouchableOpacity, Linking} from 'react-native';
+import {View, StatusBar, Platform, Text, TouchableOpacity, Linking} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
 import { useNavigation } from '@react-navigation/native';
 import {ChevronLeftIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import WisdomLogo from '../../assets/wisdomLogo.tsx'
 
 

--- a/Wisdom_expo/screens/start/EnterEmailScreen.js
+++ b/Wisdom_expo/screens/start/EnterEmailScreen.js
@@ -1,6 +1,6 @@
 
 import React, {useState } from 'react';
-import {View, StatusBar,SafeAreaView, Platform,Text, TouchableOpacity, TextInput, KeyboardAvoidingView, Animated, TouchableWithoutFeedback, Keyboard} from 'react-native';
+import {View, StatusBar, Platform,Text, TouchableOpacity, TextInput, KeyboardAvoidingView, Animated, TouchableWithoutFeedback, Keyboard} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -8,6 +8,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import {ChevronLeftIcon} from 'react-native-heroicons/outline';
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 import api from '../../utils/api';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/start/EnterNameScreen.js
+++ b/Wisdom_expo/screens/start/EnterNameScreen.js
@@ -1,11 +1,12 @@
 
 import React, {useState } from 'react';
-import {View, StatusBar,SafeAreaView, Platform,Text, TouchableOpacity, TextInput, KeyboardAvoidingView, Animated, TouchableWithoutFeedback, Keyboard} from 'react-native';
+import {View, StatusBar, Platform,Text, TouchableOpacity, TextInput, KeyboardAvoidingView, Animated, TouchableWithoutFeedback, Keyboard} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {ChevronLeftIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 
 

--- a/Wisdom_expo/screens/start/EnterPasswordScreen.js
+++ b/Wisdom_expo/screens/start/EnterPasswordScreen.js
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, StatusBar, SafeAreaView, Platform, Text, TouchableOpacity, TextInput, KeyboardAvoidingView, TouchableWithoutFeedback, Keyboard } from 'react-native';
+import { View, StatusBar, Platform, Text, TouchableOpacity, TextInput, KeyboardAvoidingView, TouchableWithoutFeedback, Keyboard } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { useColorScheme } from 'nativewind';
@@ -7,6 +7,7 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import { ChevronLeftIcon } from 'react-native-heroicons/outline';
 import EyeIcon from 'react-native-bootstrap-icons/icons/eye';
 import EyeSlashIcon from 'react-native-bootstrap-icons/icons/eye-slash';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage';
 
 export default function EnterPasswordScreen() {

--- a/Wisdom_expo/screens/start/ForgotPassword.js
+++ b/Wisdom_expo/screens/start/ForgotPassword.js
@@ -1,7 +1,7 @@
 
 
 import React, {useState } from 'react';
-import {View, StatusBar, SafeAreaView, Platform,Text, TouchableOpacity, TextInput, KeyboardAvoidingView, Animated} from 'react-native';
+import {View, StatusBar, Platform,Text, TouchableOpacity, TextInput, KeyboardAvoidingView, Animated} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -9,6 +9,7 @@ import { useNavigation } from '@react-navigation/native';
 import {ChevronLeftIcon} from 'react-native-heroicons/outline';
 import WisdomLogo from '../../assets/wisdomLogo.tsx';
 import api from '../../utils/api';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function ForgotPasswordScreen() {

--- a/Wisdom_expo/screens/start/GetStartedScreen.js
+++ b/Wisdom_expo/screens/start/GetStartedScreen.js
@@ -1,11 +1,12 @@
 
 import React from 'react';
-import { View, StatusBar, SafeAreaView, Platform, Text, TouchableOpacity, Image, Dimensions } from 'react-native';
+import { View, StatusBar, Platform, Text, TouchableOpacity, Image, Dimensions } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'react-native'
 import '../../languages/i18n';
 import WisdomLogo from '../../assets/wisdomLogo.tsx'
 import { useNavigation } from '@react-navigation/native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { XMarkIcon } from 'react-native-heroicons/outline';
 
 

--- a/Wisdom_expo/screens/start/LogInScreen.js
+++ b/Wisdom_expo/screens/start/LogInScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Keyboard, StatusBar, SafeAreaView, Platform, Text, TouchableOpacity, TextInput, KeyboardAvoidingView } from 'react-native';
+import { View, Keyboard, StatusBar, Platform, Text, TouchableOpacity, TextInput, KeyboardAvoidingView } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { useColorScheme } from 'nativewind';
@@ -11,6 +11,7 @@ import WisdomLogo from '../../assets/wisdomLogo.tsx';
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import { storeDataLocally, getDataLocally } from '../../utils/asyncStorage.js';
 import api, { setTokens } from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/start/LogOptionScreen.js
+++ b/Wisdom_expo/screens/start/LogOptionScreen.js
@@ -1,6 +1,6 @@
 
 import React, { useEffect, useState } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, TouchableOpacity, Text, Dimensions, Image} from 'react-native';
+import {View, StatusBar, Platform, TouchableOpacity, Text, Dimensions, Image} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
@@ -10,6 +10,7 @@ import WisdomLogo from '../../assets/wisdomLogo.tsx'
 import GoogleLogo from '../../assets/GoogleLogo.svg'
 import AppleLogo from '../../assets/AppleLogo.svg'
 import FacebookLogo from '../../assets/FacebookLogo.svg';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import axios from 'axios';
 // import * as Google from 'expo-auth-session/providers/google';
 // import * as WebBrowser from "expo-web-browser";

--- a/Wisdom_expo/screens/start/NewPasswordScreen.js
+++ b/Wisdom_expo/screens/start/NewPasswordScreen.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Keyboard, StatusBar, SafeAreaView, Platform, Text, TouchableOpacity, TextInput, KeyboardAvoidingView } from 'react-native';
+import { View, Keyboard, StatusBar, Platform, Text, TouchableOpacity, TextInput, KeyboardAvoidingView } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import '../../languages/i18n';
 import { useColorScheme } from 'nativewind';
@@ -11,6 +11,7 @@ import WisdomLogo from '../../assets/wisdomLogo.tsx'
 import { KeyboardAwareScrollView } from 'react-native-keyboard-aware-scroll-view';
 import api, { setTokens } from '../../utils/api';
 import { storeDataLocally } from '../../utils/asyncStorage';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/start/NotificationAllowScreen.js
+++ b/Wisdom_expo/screens/start/NotificationAllowScreen.js
@@ -1,6 +1,6 @@
 
 import React, {useState} from 'react';
-import {View, StatusBar,SafeAreaView, Platform, Text, Alert, TouchableOpacity, ScrollView} from 'react-native';
+import {View, StatusBar, Platform, Text, Alert, TouchableOpacity, ScrollView} from 'react-native';
 import * as Notifications from 'expo-notifications';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
@@ -12,6 +12,7 @@ import {XMarkIcon} from 'react-native-heroicons/outline';
 import NotificationAskWhite from '../../assets/NotificationAskWhite.svg';
 import NotificationAskDark from '../../assets/NotificationAskDark.svg';
 import api, { setTokens } from '../../utils/api.js';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 

--- a/Wisdom_expo/screens/start/PrivacyPolicyScreen.js
+++ b/Wisdom_expo/screens/start/PrivacyPolicyScreen.js
@@ -1,11 +1,12 @@
 
 import React, { useEffect } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, ScrollView, Text, TouchableOpacity} from 'react-native';
+import {View, StatusBar, Platform, ScrollView, Text, TouchableOpacity} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
 import { useNavigation } from '@react-navigation/native';
 import {ChevronLeftIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function PrivacyPolicy() {

--- a/Wisdom_expo/screens/start/TermsScreen.js
+++ b/Wisdom_expo/screens/start/TermsScreen.js
@@ -1,11 +1,12 @@
 
 import React, { useEffect } from 'react'
-import {View, StatusBar, SafeAreaView, Platform, ScrollView, Text, TouchableOpacity} from 'react-native';
+import {View, StatusBar, Platform, ScrollView, Text, TouchableOpacity} from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useColorScheme } from 'nativewind'
 import '../../languages/i18n';
 import { useNavigation } from '@react-navigation/native';
 import {ChevronLeftIcon} from 'react-native-heroicons/outline';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 
 export default function TermsScreen() {


### PR DESCRIPTION
## Summary
- replace SafeAreaView imports from `react-native` with `react-native-safe-area-context` across all screen components to resolve the deprecation warning.

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5a9bd1f54832bbe559ea89966dd0a