### PR TITLE
Remove SafeAreaView edge overrides on non-tab screens

### DIFF
--- a/Wisdom_expo/screens/booking/BookingDetailsScreen.js
+++ b/Wisdom_expo/screens/booking/BookingDetailsScreen.js
@@ -829,7 +829,7 @@ export default function BookingDetailsScreen() {
       : null;
 
   if (!booking) {
-    return <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]' />;
+    return <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]' />;
   }
 
   return (
@@ -1115,7 +1115,7 @@ export default function BookingDetailsScreen() {
 
       </RBSheet>
 
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
         <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
 
         <View className='items-center justify-center px-2 pt-3  pb-3'>

--- a/Wisdom_expo/screens/booking/BookingScreen.js
+++ b/Wisdom_expo/screens/booking/BookingScreen.js
@@ -618,7 +618,7 @@ export default function BookingScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <RBSheet

--- a/Wisdom_expo/screens/booking/PaymentMethodScreen.js
+++ b/Wisdom_expo/screens/booking/PaymentMethodScreen.js
@@ -138,7 +138,7 @@ export default function PaymentMethodScreen() {
 
   if (processing) {
     return (
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-center items-center'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-center items-center'>
         <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
         <CreditCard height={60} width={60} strokeWidth={1.5} color={iconColor} />
         <ActivityIndicator className='mt-4' size='large' color={colorScheme === 'dark' ? '#fcfcfc' : '#323131'} />
@@ -150,7 +150,7 @@ export default function PaymentMethodScreen() {
   }
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <View className='absolute bg-[#f2f2f2] dark:bg-[#272626] h-[100px] w-full z-10 justify-end'>

--- a/Wisdom_expo/screens/booking/SetFinalPriceScreen.js
+++ b/Wisdom_expo/screens/booking/SetFinalPriceScreen.js
@@ -179,11 +179,11 @@ export default function SetFinalPriceScreen() {
     }
   };
 
-  if (loading) return <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]' />;
+  if (loading) return <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]' />;
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]">
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]">
         <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
         <View className="flex-1 px-6 pt-5 pb-6">
           <TouchableOpacity onPress={() => navigation.goBack()}>

--- a/Wisdom_expo/screens/chat/ChatImageViewerScreen.js
+++ b/Wisdom_expo/screens/chat/ChatImageViewerScreen.js
@@ -36,7 +36,7 @@ export default function ChatImageViewerScreen() {
   const getScale = (idx) => (idx === currentIndex ? 1 : 0.85);
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
 
       <View className="px-6 pt-3 pb-3 justify-center items-center">

--- a/Wisdom_expo/screens/chat/ConversationScreen.js
+++ b/Wisdom_expo/screens/chat/ConversationScreen.js
@@ -596,7 +596,7 @@ export default function ConversationScreen() {
   // ---------------------------------------------------------------------------
   return (
     <View className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]">
-      <SafeAreaView edges={['top', 'left', 'right']} className="bg-[#fcfcfc] dark:bg-[#202020] rounded-b-[30px]">
+      <SafeAreaView className="bg-[#fcfcfc] dark:bg-[#202020] rounded-b-[30px]">
         <StatusBar barStyle={colorScheme === 'dark' ? 'light-content' : 'dark-content'} />
 
         {/* Header */}

--- a/Wisdom_expo/screens/common/TemplateScreen.js
+++ b/Wisdom_expo/screens/common/TemplateScreen.js
@@ -15,7 +15,7 @@ export default function TemplateScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
     </SafeAreaView>
   );

--- a/Wisdom_expo/screens/favorites/ListScreen.js
+++ b/Wisdom_expo/screens/favorites/ListScreen.js
@@ -251,7 +251,7 @@ export default function ListScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <RBSheet
         height={sheetHeight}

--- a/Wisdom_expo/screens/home/AddReviewScreen.js
+++ b/Wisdom_expo/screens/home/AddReviewScreen.js
@@ -63,7 +63,7 @@ export default function AddReviewScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]">
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]">
         <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <View className="flex-1 px-6 pt-5 pb-6 justify-between">
         <View>

--- a/Wisdom_expo/screens/home/ConfirmPaymentScreen.js
+++ b/Wisdom_expo/screens/home/ConfirmPaymentScreen.js
@@ -34,7 +34,7 @@ export default function ConfirmPaymentScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <View className="flex-1 justify-start items-center">

--- a/Wisdom_expo/screens/home/DisplayImagesScreen.js
+++ b/Wisdom_expo/screens/home/DisplayImagesScreen.js
@@ -29,7 +29,7 @@ export default function DisplayImagesScreen() {
   );
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <View className="px-6 pt-10 pb-3 justify-center items-center">
         

--- a/Wisdom_expo/screens/home/DisplayReviewsScreen.js
+++ b/Wisdom_expo/screens/home/DisplayReviewsScreen.js
@@ -45,7 +45,7 @@ export default function DisplayReviewsScreen() {
   );
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <View className="px-6 pt-10 pb-3 justify-center items-center">
         <View className="mb-6 w-full flex-row justify-center items-center">

--- a/Wisdom_expo/screens/home/EnlargedImageScreen.js
+++ b/Wisdom_expo/screens/home/EnlargedImageScreen.js
@@ -42,7 +42,7 @@ export default function EnlargedImageScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <View className="px-6 pt-10 pb-3 justify-center items-center">
         <View className="mb-6 w-full flex-row justify-between items-center">

--- a/Wisdom_expo/screens/home/ResultsScreen.js
+++ b/Wisdom_expo/screens/home/ResultsScreen.js
@@ -345,7 +345,7 @@ export default function ResultsScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <RBSheet

--- a/Wisdom_expo/screens/home/SearchDirectionScreen.js
+++ b/Wisdom_expo/screens/home/SearchDirectionScreen.js
@@ -441,7 +441,7 @@ export default function SearchDirectionScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <RBSheet

--- a/Wisdom_expo/screens/home/SearchScreen.js
+++ b/Wisdom_expo/screens/home/SearchScreen.js
@@ -15,7 +15,7 @@ export default function SearchScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
     </SafeAreaView>
   );

--- a/Wisdom_expo/screens/home/SearchServiceScreen.js
+++ b/Wisdom_expo/screens/home/SearchServiceScreen.js
@@ -164,7 +164,7 @@ export default function SearchServiceScreen() {
   )};
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
       
       <View className="px-5 pt-4 flex-1">

--- a/Wisdom_expo/screens/home/ServiceProfileScreen.js
+++ b/Wisdom_expo/screens/home/ServiceProfileScreen.js
@@ -827,7 +827,7 @@ export default function ServiceProfileScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#fcfcfc] dark:bg-[#323131]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <RBSheet

--- a/Wisdom_expo/screens/professional/WalletProScreen.js
+++ b/Wisdom_expo/screens/professional/WalletProScreen.js
@@ -68,7 +68,7 @@ export default function WalletProScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
       
       <View className="absolute bg-[#f2f2f2] dark:bg-[#272626] h-[90px] w-full z-10 justify-end">

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodBirthScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodBirthScreen.js
@@ -23,7 +23,7 @@ export default function CollectionMethodBirthScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
       <View className="flex-1 px-6 pt-5 pb-6">
         <TouchableOpacity onPress={() => navigation.navigate('WalletPro')}>

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodConfirmScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodConfirmScreen.js
@@ -69,7 +69,7 @@ export default function CollectionMethodConfirmScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
         
         <View className="flex-1 px-6 pt-5 pb-6">

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodDirectionScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodDirectionScreen.js
@@ -56,7 +56,7 @@ export default function CollectionMethodDirectionScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
         <ScrollView contentContainerStyle={{flexGrow:1}}>
 

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodDniScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodDniScreen.js
@@ -54,7 +54,7 @@ export default function CollectionMethodDniScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
         <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
         <View className="flex-1 px-6 pt-5 pb-6">
           <TouchableOpacity onPress={() => navigation.navigate('WalletPro')}>

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodIbanScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodIbanScreen.js
@@ -21,7 +21,7 @@ export default function CollectionMethodIbanScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
         <View className="flex-1 px-6 pt-5 pb-6">
             <TouchableOpacity onPress={() => navigation.navigate('WalletPro')}>

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodNameScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodNameScreen.js
@@ -19,7 +19,7 @@ export default function CollectionMethodNameScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
         <View className="flex-1 px-6 pt-5 pb-6">
             <TouchableOpacity onPress={() => navigation.goBack()}>

--- a/Wisdom_expo/screens/professional/collection_method/CollectionMethodPhoneScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/CollectionMethodPhoneScreen.js
@@ -21,7 +21,7 @@ export default function CollectionMethodPhoneScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
         <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
           <View className="flex-1 px-6 pt-5 pb-6">
             <TouchableOpacity onPress={() => navigation.navigate('WalletPro')}>

--- a/Wisdom_expo/screens/professional/collection_method/DniCameraScreen.js
+++ b/Wisdom_expo/screens/professional/collection_method/DniCameraScreen.js
@@ -48,7 +48,7 @@ export default function DniCameraScreen() {
 
   if (!permission.granted) {
     return (
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0, backgroundColor: colorScheme === 'dark' ? '#272626' : '#f2f2f2' }}>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0, backgroundColor: colorScheme === 'dark' ? '#272626' : '#f2f2f2' }}>
         <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', padding: 24 }}>
           <Text className="font-inter-medium text-[16px]" style={{ color: iconColor, textAlign: 'center', marginBottom: 18 }}>{t('permission_denied')}</Text>
           <TouchableOpacity onPress={requestPermission} className="rounded-full px-5 py-3" style={{ backgroundColor: colorScheme === 'dark' ? '#fcfcfc' : '#323131' }}>
@@ -109,7 +109,7 @@ export default function DniCameraScreen() {
         </View>
       </View>
 
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ position: 'absolute', top: 0, left: 0, right: 0 }}>
+      <SafeAreaView style={{ position: 'absolute', top: 0, left: 0, right: 0 }}>
         <View style={{ paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0, flexDirection: 'row', alignItems: 'center' }}>
           <TouchableOpacity onPress={() => navigation.goBack()} className="pl-6 pt-5">
             <ChevronLeftIcon size={24} color={'#ffffff'} strokeWidth={1.8}/>

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceAskScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceAskScreen.js
@@ -38,7 +38,7 @@ export default function CreateServiceAskScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
         <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
           
           <View className="flex-1 px-6 pt-5 pb-6">

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceClassificationScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceClassificationScreen.js
@@ -131,7 +131,7 @@ export default function CreateServiceClassificationScreen() {
   const dropdownTop = (anchor) => (anchor ? anchor.y + anchor.height : 0);
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']}
+    <SafeAreaView
       style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }}
       className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]"
     >

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceConsultScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceConsultScreen.js
@@ -80,7 +80,7 @@ export default function CreateServiceConsultScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
         <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
           
           <View className="flex-1 px-6 pt-5 pb-6">

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDescriptionScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDescriptionScreen.js
@@ -56,7 +56,7 @@ export default function CreateServiceDescriptionScreen() {
   }, []);
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
         <ScrollView contentContainerStyle={{ flexGrow: 1 }}>
           <View className="flex-1 px-6 pt-5 pb-6">

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDetailsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDetailsScreen.js
@@ -126,7 +126,7 @@ export default function CreateServiceDetailsScreen() {
   }, []);
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         <ScrollView className="flex-1 px-6 pt-5 pb-6">
 

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceDiscountsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceDiscountsScreen.js
@@ -45,7 +45,7 @@ export default function CreateServiceDiscountsScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         
         <View className="flex-1 px-6 pt-5 pb-6">

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceExperiencesScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceExperiencesScreen.js
@@ -138,7 +138,7 @@ export default function CreateServiceExperiencesScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={{ flexGrow: 1 }}>

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceImagesScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceImagesScreen.js
@@ -156,7 +156,7 @@ export default function CreateServiceImagesScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
 
       <ScrollView contentContainerStyle={{ flexGrow: 1 }} showsVerticalScrollIndicator={false}>

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceLocationScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceLocationScreen.js
@@ -135,7 +135,7 @@ export default function CreateServiceLocationScreen() {
       };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <View className="flex-1 px-6 pt-5 pb-6">

--- a/Wisdom_expo/screens/professional/create_service/CreateServicePriceScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServicePriceScreen.js
@@ -94,7 +94,7 @@ export default function CreateServicePriceScreen() {
 
   return (
     <TouchableWithoutFeedback onPress={Keyboard.dismiss} accessible={false}>
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]">
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]">
         <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
         <View className="flex-1 px-6 pt-5 pb-6">

--- a/Wisdom_expo/screens/professional/create_service/CreateServicePriceTypeScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServicePriceTypeScreen.js
@@ -47,7 +47,7 @@ export default function CreateServicePriceTypeScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         
         <View className="flex-1 px-6 pt-5 pb-6">

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceReviewScreen.js
@@ -586,7 +586,7 @@ export default function CreateServiceReviewScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         <View className="flex-1 pb-6">
             <TouchableOpacity onPress={() => navigation.navigate('CreateServiceTerms', { prevParams })} className='pt-5 pb-1 px-6'>

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceStartScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceStartScreen.js
@@ -38,7 +38,7 @@ export default function CreateServiceStartScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         <View className="flex-1 px-6 pt-5 pb-6">
             <TouchableOpacity onPress={() => navigation.pop(1)}>

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceTermsScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceTermsScreen.js
@@ -22,7 +22,7 @@ export default function CreateServiceTermsScreen() {
   } = prevParams;
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         <View className="flex-1 px-6 pt-5 pb-6">
             <TouchableOpacity onPress={() => navigation.navigate('CreateServiceConsult', { prevParams })}>

--- a/Wisdom_expo/screens/professional/create_service/CreateServiceTitleScreen.js
+++ b/Wisdom_expo/screens/professional/create_service/CreateServiceTitleScreen.js
@@ -26,7 +26,7 @@ export default function CreateServiceTitleScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         <View className="flex-1 px-6 pt-5 pb-6">
             <TouchableOpacity onPress={() => navigation.pop(2)}>

--- a/Wisdom_expo/screens/services/CalendarScreen.js
+++ b/Wisdom_expo/screens/services/CalendarScreen.js
@@ -165,7 +165,7 @@ export default function CalendarScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <View className="flex-1 justify-start items-center pt-[55px] ">

--- a/Wisdom_expo/screens/settings/CancellationPolicyScreen.js
+++ b/Wisdom_expo/screens/settings/CancellationPolicyScreen.js
@@ -17,7 +17,7 @@ export default function CancellationPolicyScreen() {
   const textStyle = 'mb-2 font-inter-medium';
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']}
+    <SafeAreaView
       style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }}
       className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'
     >

--- a/Wisdom_expo/screens/settings/ChangePasswordScreen.js
+++ b/Wisdom_expo/screens/settings/ChangePasswordScreen.js
@@ -95,7 +95,7 @@ export default function ChangePasswordScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <View className="absolute bg-[#f2f2f2] dark:bg-[#272626] h-[95px] w-full z-10 justify-end">
         <View className="flex-row justify-between items-center pb-4 px-2">

--- a/Wisdom_expo/screens/settings/DirectionsScreen.js
+++ b/Wisdom_expo/screens/settings/DirectionsScreen.js
@@ -153,7 +153,7 @@ export default function DirectionsScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]">
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]">
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
 
       <RBSheet

--- a/Wisdom_expo/screens/settings/EditAccountScreen.js
+++ b/Wisdom_expo/screens/settings/EditAccountScreen.js
@@ -173,7 +173,7 @@ export default function EditAccountScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
       <View className="absolute bg-[#f2f2f2] dark:bg-[#272626] h-[95px] w-full z-10 justify-end">

--- a/Wisdom_expo/screens/settings/EditProfileScreen.js
+++ b/Wisdom_expo/screens/settings/EditProfileScreen.js
@@ -267,7 +267,7 @@ export default function EditProfileScreen() {
 
 
     return (
-        <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+        <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
             <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
 
             <View className="absolute bg-[#f2f2f2] dark:bg-[#272626] h-[95px] w-full z-10 justify-end">

--- a/Wisdom_expo/screens/settings/ExpertPlansScreen.js
+++ b/Wisdom_expo/screens/settings/ExpertPlansScreen.js
@@ -42,7 +42,7 @@ export default function ExpertPlansScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
       <View className="flex-1">
 

--- a/Wisdom_expo/screens/settings/FAQScreen.js
+++ b/Wisdom_expo/screens/settings/FAQScreen.js
@@ -37,7 +37,7 @@ export default function FAQScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
 
       <View className="absolute bg-[#f2f2f2] dark:bg-[#272626] h-[90px] w-full z-10 justify-end">

--- a/Wisdom_expo/screens/settings/HelpScreen.js
+++ b/Wisdom_expo/screens/settings/HelpScreen.js
@@ -37,7 +37,7 @@ export default function HelpScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
       
       <View className="absolute bg-[#f2f2f2] dark:bg-[#272626] h-[90px] w-full z-10 justify-end">

--- a/Wisdom_expo/screens/settings/LanguageScreen.js
+++ b/Wisdom_expo/screens/settings/LanguageScreen.js
@@ -55,7 +55,7 @@ export default function LanguageScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']}
+    <SafeAreaView
       style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }}
       className="flex-1 bg-[#f2f2f2] dark:bg-[#272626]"
     >

--- a/Wisdom_expo/screens/settings/PreferencesScreen.js
+++ b/Wisdom_expo/screens/settings/PreferencesScreen.js
@@ -66,7 +66,7 @@ export default function PreferencesScreen() {
   };
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
       <View className="absolute bg-[#f2f2f2] dark:bg-[#272626] h-[90px] w-full z-10 justify-end">
         <View className="flex-row justify-between items-center pb-4 px-2">

--- a/Wisdom_expo/screens/settings/ReservationPolicyScreen.js
+++ b/Wisdom_expo/screens/settings/ReservationPolicyScreen.js
@@ -17,7 +17,7 @@ export default function ReservationPolicyScreen() {
   const textStyle = 'mb-2 font-inter-medium';
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
       <View className="pl-5 py-3">
         <TouchableOpacity onPress={() => navigation.goBack()}>

--- a/Wisdom_expo/screens/settings/TurnExpertScreen.js
+++ b/Wisdom_expo/screens/settings/TurnExpertScreen.js
@@ -21,7 +21,7 @@ export default function TurnExpertScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
       <View className="flex-1 justify-start items-center">
 

--- a/Wisdom_expo/screens/settings/WalletScreen.js
+++ b/Wisdom_expo/screens/settings/WalletScreen.js
@@ -68,7 +68,7 @@ export default function WalletScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
       
       <View className="absolute bg-[#f2f2f2] dark:bg-[#272626] h-[90px] w-full z-10 justify-end">

--- a/Wisdom_expo/screens/settings/WisdomWarrantyScreen.js
+++ b/Wisdom_expo/screens/settings/WisdomWarrantyScreen.js
@@ -17,7 +17,7 @@ export default function WisdomWarrantyScreen() {
   const textStyle = 'mb-2 font-inter-medium';
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']}
+    <SafeAreaView
       style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }}
       className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'
     >

--- a/Wisdom_expo/screens/start/CreateProfileScreen.js
+++ b/Wisdom_expo/screens/start/CreateProfileScreen.js
@@ -140,7 +140,7 @@ export default function CreateProfileScreen() {
     };
 
     return (
-        <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
+        <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
             <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
             <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()} accessible={false}>
             <View className="flex-1 w-full justify-between items-center ">

--- a/Wisdom_expo/screens/start/EmailSendedScreen.js
+++ b/Wisdom_expo/screens/start/EmailSendedScreen.js
@@ -33,7 +33,7 @@ export default function EmailSendedScreen({ route }) {
     };
 
     return (
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
         <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
           <View className="px-5 py-3  w-full">
             <View className="flex-row justify-between">

--- a/Wisdom_expo/screens/start/EnterEmailScreen.js
+++ b/Wisdom_expo/screens/start/EnterEmailScreen.js
@@ -63,7 +63,7 @@ export default function EnterEmailScreen() {
     }
 
     return (
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
         <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()} accessible={false} >
         <View className="flex-1 w-full justify-between items-center">

--- a/Wisdom_expo/screens/start/EnterNameScreen.js
+++ b/Wisdom_expo/screens/start/EnterNameScreen.js
@@ -53,7 +53,7 @@ export default function EnterNameScreen() {
     }
 
     return (
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
         <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()} accessible={false}>
         <View className="flex-1 w-full justify-between items-center">

--- a/Wisdom_expo/screens/start/EnterPasswordScreen.js
+++ b/Wisdom_expo/screens/start/EnterPasswordScreen.js
@@ -40,7 +40,7 @@ export default function EnterPasswordScreen() {
   }
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1  bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1  bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
       
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()} accessible={false}>

--- a/Wisdom_expo/screens/start/ForgotPasswordScreen.js
+++ b/Wisdom_expo/screens/start/ForgotPasswordScreen.js
@@ -43,7 +43,7 @@ export default function ForgotPasswordScreen() {
     }
 
     return (
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
         <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
           <View className="px-5 py-3  w-full">
             <View className="flex-row justify-between">

--- a/Wisdom_expo/screens/start/GetStartedScreen.js
+++ b/Wisdom_expo/screens/start/GetStartedScreen.js
@@ -18,7 +18,7 @@ export default function GetStartedScreen() {
     const windowHeight = Dimensions.get('window').height;
 
     return (
-        <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-neutral-700 justify-between'>
+        <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1 bg-neutral-700 justify-between'>
             <Image source={require('../../assets/LoadChair.png')} style={{ height: windowHeight, width: windowWidth, position: 'absolute' }} />
             <StatusBar style={colorScheme == 'dark' ? 'light' : 'dark'} />
             <View>

--- a/Wisdom_expo/screens/start/LogInScreen.js
+++ b/Wisdom_expo/screens/start/LogInScreen.js
@@ -105,7 +105,7 @@ export default function LogInScreen() {
 
   return (
     
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1  bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1  bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <KeyboardAwareScrollView style={{ flex: 1, width: '100%' }} enableOnAndroid={true} scrollEnabled={keyboardOpen} > 
       <View className="px-5 py-3 w-full">

--- a/Wisdom_expo/screens/start/LogOptionScreen.js
+++ b/Wisdom_expo/screens/start/LogOptionScreen.js
@@ -73,7 +73,7 @@ export default function LogOptionScreen() {
     
     return (
         
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 w-full bg-neutral-700 justify-between'>
+      <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 w-full bg-neutral-700 justify-between'>
         <Image source={require('../../assets/LoadChair.png')}  style={{ height: windowHeight, width: windowWidth, position: 'absolute' }}/>
         <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
           <View>

--- a/Wisdom_expo/screens/start/NewPasswordScreen.js
+++ b/Wisdom_expo/screens/start/NewPasswordScreen.js
@@ -108,7 +108,7 @@ export default function NewPasswordScreen({ route }) {
 
   return (
     
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1  bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0 }} className='flex-1  bg-[#f2f2f2] dark:bg-[#272626] justify-between items-center'>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <KeyboardAwareScrollView style={{ flex: 1, width: '100%' }} enableOnAndroid={true} scrollEnabled={keyboardOpen} > 
       <View className="px-5 py-3 w-full">

--- a/Wisdom_expo/screens/start/NotificationAllowScreen.js
+++ b/Wisdom_expo/screens/start/NotificationAllowScreen.js
@@ -187,7 +187,7 @@ export default function NotificationAllowScreen() {
   }
   
     return (
-      <SafeAreaView edges={['top', 'left', 'right']} style={{ paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+      <SafeAreaView style={{ paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
         <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
         <View className="px-5 py-3 w-full flex-1 justify-between">
           <View className="flex-row justify-between">

--- a/Wisdom_expo/screens/start/PrivacyPolicyScreen.js
+++ b/Wisdom_expo/screens/start/PrivacyPolicyScreen.js
@@ -20,7 +20,7 @@ export default function PrivacyPolicy() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
       <View className="pl-5 py-3 ">
         <TouchableOpacity onPress={() => navigation.goBack()}>

--- a/Wisdom_expo/screens/start/TermsScreen.js
+++ b/Wisdom_expo/screens/start/TermsScreen.js
@@ -21,7 +21,7 @@ export default function TermsScreen() {
 
 
   return (
-    <SafeAreaView edges={['top', 'left', 'right']} style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
+    <SafeAreaView style={{ flex: 1, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight : 0}} className='flex-1 bg-[#f2f2f2] dark:bg-[#272626]'>
       <StatusBar style = {colorScheme=='dark'? 'light': 'dark'}/>
       <View className="pl-5 py-3">
         <TouchableOpacity onPress={() => navigation.goBack()}>


### PR DESCRIPTION
## Summary
- remove the SafeAreaView edge overrides from screens that do not display the bottom tab navigator so the bottom inset is respected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8044a33a0832b812f7efbc0f5b82b