### PR TITLE
Fix Expo module Gradle plugin extra usage

### DIFF
--- a/Wisdom_expo/patches/expo-modules-core+3.0.16.patch
+++ b/Wisdom_expo/patches/expo-modules-core+3.0.16.patch
@@ -1,0 +1,96 @@
+diff --git a/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt b/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
+index 71d54fc..bd1fd95 100644
+--- a/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
++++ b/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ExpoModulesGradlePlugin.kt
+@@ -7,7 +7,7 @@ import expo.modules.plugin.gradle.ExpoGradleHelperExtension
+ import expo.modules.plugin.gradle.ExpoModuleExtension
+ import org.gradle.api.Plugin
+ import org.gradle.api.Project
+-import org.gradle.internal.extensions.core.extra
++import org.gradle.api.plugins.ExtensionAware
+ 
+ private val lock = Any()
+ 
+@@ -42,12 +42,14 @@ abstract class ExpoModulesGradlePlugin : Plugin<Project> {
+   }
+ 
+   private fun getKotlinVersion(project: Project): String {
+-    return project.rootProject.extra.safeGet<String>("kotlinVersion")
++    val extras = (project.rootProject as ExtensionAware).extensions.extraProperties
++    return extras.safeGet<String>("kotlinVersion")
+       ?: project.logger.warnIfNotDefined("kotlinVersion", "2.0.21")
+   }
+ 
+   private fun getKSPVersion(project: Project): String {
+-    return project.rootProject.extra.safeGet<String>("kspVersion")
++    val extras = (project.rootProject as ExtensionAware).extensions.extraProperties
++    return extras.safeGet<String>("kspVersion")
+       ?: project.logger.warnIfNotDefined("kspVersion", "2.0.21-1.0.28")
+   }
+ }
+diff --git a/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt b/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+index 7c22069..eb7ffb5 100644
+--- a/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
++++ b/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/ProjectConfiguration.kt
+@@ -15,7 +15,7 @@ import expo.modules.plugin.android.createReleasePublication
+ import expo.modules.plugin.gradle.ExpoModuleExtension
+ import org.gradle.api.Project
+ import org.gradle.api.publish.PublishingExtension
+-import org.gradle.internal.extensions.core.extra
++import org.gradle.api.plugins.ExtensionAware
+ import java.io.File
+ 
+ internal fun Project.applyDefaultPlugins() {
+@@ -31,8 +31,9 @@ internal fun Project.applyDefaultPlugins() {
+ }
+ 
+ internal fun Project.applyKotlin(kotlinVersion: String, kspVersion: String) {
+-  extra.set("kotlinVersion", kotlinVersion)
+-  extra.set("kspVersion", kspVersion)
++  val extras = (this as ExtensionAware).extensions.extraProperties
++  extras.set("kotlinVersion", kotlinVersion)
++  extras.set("kspVersion", kspVersion)
+ 
+   project.dependencies.add("implementation", "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion")
+ }
+@@ -48,13 +49,14 @@ internal fun Project.applyDefaultDependencies() {
+ }
+ 
+ internal fun Project.applyDefaultAndroidSdkVersions() {
++  val rootExtras = (rootProject as ExtensionAware).extensions.extraProperties
+   with(androidLibraryExtension()) {
+     applySDKVersions(
+-      compileSdk = rootProject.extra.safeGet("compileSdkVersion")
++      compileSdk = rootExtras.safeGet("compileSdkVersion")
+         ?: logger.warnIfNotDefined("compileSdkVersion", 36),
+-      minSdk = rootProject.extra.safeGet("minSdkVersion")
++      minSdk = rootExtras.safeGet("minSdkVersion")
+         ?: logger.warnIfNotDefined("minSdkVersion", 24),
+-      targetSdk = rootProject.extra.safeGet("targetSdkVersion")
++      targetSdk = rootExtras.safeGet("targetSdkVersion")
+         ?: logger.warnIfNotDefined("targetSdkVersion", 36)
+     )
+     applyLinterOptions()
+diff --git a/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt b/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+index 896cc50..efdd3d0 100644
+--- a/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
++++ b/node_modules/expo-modules-core/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/gradle/ExpoModuleExtension.kt
+@@ -7,7 +7,7 @@ import java.io.File
+ import java.util.Properties
+ import expo.modules.plugin.Version
+ import expo.modules.plugin.safeGet
+-import org.gradle.internal.extensions.core.extra
++import org.gradle.api.plugins.ExtensionAware
+ 
+ /**
+  * An user-facing interface to interact with the `ExpoGradleHelperExtension`.
+@@ -31,7 +31,8 @@ open class ExpoModuleExtension(val project: Project) {
+     get() = gradleHelper.getReactNativeVersion(project)
+ 
+   fun safeExtGet(name: String, default: Any): Any {
+-    return project.rootProject.extra.safeGet<Any>(name) ?: default
++    val extras = (project.rootProject as ExtensionAware).extensions.extraProperties
++    return extras.safeGet<Any>(name) ?: default
+   }
+ 
+   fun getExpoDependency(name: String): Any {


### PR DESCRIPTION
## Summary
- add a patch for `expo-modules-core` that avoids relying on the deprecated `extra` shortcut in the Expo module Gradle plugin
- read and write Gradle extra properties via `ExtensionAware.extensions.extraProperties` so Gradle 8.8/Kotlin 2.0 builds no longer fail when compiling the plugin

## Testing
- `./gradlew --console=plain :expo-module-gradle-plugin:compileKotlin` *(fails later while evaluating :app because the Android Gradle plugin now requires Gradle 8.13, but the Expo module plugin compiles successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68e151c925b8832b94c44f1c3bb53426