### PR TITLE
chore: update Android compile SDK to 35

### DIFF
--- a/Wisdom_expo/android/build.gradle
+++ b/Wisdom_expo/android/build.gradle
@@ -2,10 +2,10 @@
 
 buildscript {
     ext {
-        buildToolsVersion = findProperty('android.buildToolsVersion') ?: '34.0.0'
+        buildToolsVersion = findProperty('android.buildToolsVersion') ?: '35.0.0'
         minSdkVersion = Integer.parseInt(findProperty('android.minSdkVersion') ?: '24')
-        compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '34')
-        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '34')
+        compileSdkVersion = Integer.parseInt(findProperty('android.compileSdkVersion') ?: '35')
+        targetSdkVersion = Integer.parseInt(findProperty('android.targetSdkVersion') ?: '35')
         kotlinVersion = findProperty('android.kotlinVersion') ?: '2.0.21'
 
         ndkVersion = "26.1.10909125"

--- a/Wisdom_expo/android/gradle.properties
+++ b/Wisdom_expo/android/gradle.properties
@@ -27,6 +27,9 @@ android.enableJetifier=true
 
 # Minimum SDK version required by React Native 0.81+ libraries
 android.minSdkVersion=24
+android.compileSdkVersion=35
+android.targetSdkVersion=35
+android.buildToolsVersion=35.0.0
 
 # Enable AAPT2 PNG crunching
 android.enablePngCrunchInReleaseBuilds=true


### PR DESCRIPTION
## Summary
- bump the default Android build tools, compileSdk, and targetSdk to API level 35
- add matching overrides in gradle.properties so builds pick up the new defaults

## Testing
- bash gradlew :app:checkReleaseAarMetadata --console=plain *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e361e112a4832b906d74b9d2b5dd05