### PR TITLE
fix: add JetBrains Kotlin repo for Android builds

### DIFF
--- a/Wisdom_expo/android/build.gradle
+++ b/Wisdom_expo/android/build.gradle
@@ -15,6 +15,7 @@ buildscript {
         google()
         mavenCentral()
         maven { url 'https://plugins.gradle.org/m2/' }
+        maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev' }
     }
     dependencies {
         classpath('com.android.tools.build:gradle')
@@ -39,5 +40,6 @@ allprojects {
         google()
         mavenCentral()
         maven { url 'https://www.jitpack.io' }
+        maven { url 'https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev' }
     }
 }

--- a/Wisdom_expo/android/settings.gradle
+++ b/Wisdom_expo/android/settings.gradle
@@ -3,6 +3,7 @@ pluginManagement {
     gradlePluginPortal()
     google()
     mavenCentral()
+    maven { url "https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev" }
   }
   def version = providers.exec {
     commandLine("node", "-e", "console.log(require('react-native/package.json').version);")


### PR DESCRIPTION
## Summary
- add JetBrains Kotlin repository to the Gradle buildscript and project repositories
- allow Gradle to resolve the org.jetbrains.kotlin.plugin.compose plugin required by Expo modules

## Testing
- `bash gradlew help --console=plain --no-daemon` *(fails: SDK location not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f49c8890832bb1b3db85ce26557f